### PR TITLE
feat:  페이지 공통 레이아웃 컴포넌트 분리

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import { Routes, Route } from "react-router-dom";
+import AppLayout from "./layouts/AppLayout/AppLayout";
 import HomePage from "./pages/HomePage/Home";
 import StudyDetailPage from "./pages/StudyDetailPage/StudyDetail";
 import StudyFormPage from "./pages/StudyFormPage/StudyForm";
@@ -8,11 +9,13 @@ import FocusPage from "./pages/FocusPage/Focus";
 function App() {
   return (
     <Routes>
-      <Route path="/" element={<HomePage />} />
-      <Route path="/studies/new" element={<StudyFormPage />} />
-      <Route path="/studies/:studyId" element={<StudyDetailPage />} />
-      <Route path="/studies/:studyId/habits" element={<HabitPage />} />
-      <Route path="/studies/:studyId/focus" element={<FocusPage />} />
+      <Route element={<AppLayout />}>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/studies/new" element={<StudyFormPage />} />
+        <Route path="/studies/:studyId" element={<StudyDetailPage />} />
+        <Route path="/studies/:studyId/habits" element={<HabitPage />} />
+        <Route path="/studies/:studyId/focus" element={<FocusPage />} />
+      </Route>
     </Routes>
   );
 }

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -50,7 +50,7 @@
 /* ── 모바일 (~ 375px) ── */
 @media (max-width: 375px) {
   .inner {
-    padding: 0 1rem;
+    padding: 2 1rem;
   }
 
   .headerLeft img {

--- a/src/layouts/AppLayout/AppLayout.jsx
+++ b/src/layouts/AppLayout/AppLayout.jsx
@@ -1,0 +1,26 @@
+import { Outlet, useNavigate, useLocation } from "react-router-dom";
+import Header from "../../components/Header/Header";
+import styles from "./AppLayout.module.css";
+
+function AppLayout() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const showButton =
+    location.pathname === "/" || location.pathname === "/studies/new";
+
+  return (
+    <div className={styles.appWrapper}>
+      <Header
+        showButton={showButton}
+        onCreateStudy={() => navigate("/studies/new")}
+      />
+
+      <main className={styles.main}>
+        <Outlet />
+      </main>
+    </div>
+  );
+}
+
+export default AppLayout;

--- a/src/layouts/AppLayout/AppLayout.module.css
+++ b/src/layouts/AppLayout/AppLayout.module.css
@@ -1,0 +1,9 @@
+.appWrapper {
+  background-color: var(--bg-primary);
+  min-height: 100vh;
+}
+
+.main {
+  display: flex;
+  justify-content: center;
+}


### PR DESCRIPTION
## 개요
페이지 공통 구조(헤더, 배경색) 재사용을 위해 AppLayout 컴포넌트를 분리하고, 라우터를 nested route 구조로 변경했습니다.
페이지별 header와 main 간 간격이나 컨테이너 패딩이 달라 별도 별도 컴포넌트 분리 없이 각 페이지에서 직접 관리하는 방식으로 결정했습니다.

## 변경 사항
- AppLayout 생성 (헤더 + 공통 배경색)
- Router를 nested route 구조로 변경
- Header 버튼 조건부 렌더링 처리 (홈, 스터디 생성 페이지에서만 노출)
- StudyLayout 미생성 (페이지별 컨테이너 스펙 상이로 각 페이지에서 직접 관리)

## 영향 범위
- 전체 페이지 라우트 구조 변경
- 기존 각 페이지에서 개별 관리하던 헤더가 AppLayout으로 이동

## 관련 이슈
- close #2