### PR TITLE
refactor:  NavButton 공통 컴포넌트 분리

### DIFF
--- a/src/components/NavButton/NavButton.jsx
+++ b/src/components/NavButton/NavButton.jsx
@@ -1,0 +1,12 @@
+import styles from "./NavButton.module.css";
+
+function NavButton({ label, onClick }) {
+  return (
+    <button className={styles.navBtn} onClick={onClick}>
+      {label}
+      <span className="ic angle-right"></span>
+    </button>
+  );
+}
+
+export default NavButton;

--- a/src/components/NavButton/NavButton.module.css
+++ b/src/components/NavButton/NavButton.module.css
@@ -1,0 +1,27 @@
+.navBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  padding: 0.75rem 1rem 0.75rem 1.5rem;
+  border-radius: 0.9375rem;
+  border: 1px solid var(--gray-300);
+  font: var(--text-16-medium);
+  color: var(--gray-500);
+  background-color: var(--white);
+  transition: all 0.15s ease;
+}
+
+.navBtn:hover {
+  background-color: var(--gray-200);
+}
+
+.navBtn:active {
+  border-color: var(--gray-500);
+  transform: scale(0.98);
+}
+
+.navBtn:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## 개요
여러 페이지에서 공통으로 사용되는 페이지 이동 버튼을 NavButton 컴포넌트로 분리했습니다.

## 변경 사항
- NavButton 컴포넌트 생성 (label, onClick props)
- hover, active, focus-visible 효과 추가

## 스크린샷
<img width="366" height="325" alt="스크린샷 2026-04-14 오후 7 41 00" src="https://github.com/user-attachments/assets/63cc79a6-9e63-46a5-9887-015696451d1e" />

## 영향 범위
- 공통 컴포넌트 추가로 다른 페이지에서도 재사용 가능 (노션 팀 문서의 공통 컴포넌트 docs 참고)

## 관련 이슈
- close #7