### PR TITLE
feat: BoxHeaderInfo 공통 컴포넌트 추가

### DIFF
--- a/src/components/BoxHeader/BoxHeaderInfo.jsx
+++ b/src/components/BoxHeader/BoxHeaderInfo.jsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from "react";
+import styles from "./BoxHeaderInfo.module.css";
+import Tag from "../Tag/Tag";
+
+const TITLE = {
+  point: "현재까지 획득한 포인트",
+  time: "현재 시간",
+};
+
+const BoxHeaderInfo = ({ type = "", title = null, info = null }) => {
+  const [currentTime, setCurrentTime] = useState("");
+
+  useEffect(() => {
+    if (type !== "time") return; // type 이 time 인 경우에만 useEffect 실행
+
+    const format = (date) => {
+      const yyyy = date.getFullYear();
+      const mm = String(date.getMonth() + 1).padStart(2, "0");
+      const dd = String(date.getDate()).padStart(2, "0");
+      const hours = date.getHours();
+      const meridiem = hours >= 12 ? "오후" : "오전";
+      const h = hours % 12 || 12;
+      const i = String(date.getMinutes()).padStart(2, "0");
+
+      return `${yyyy}-${mm}-${dd} ${meridiem} ${h}:${i}`;
+    };
+    setCurrentTime(format(new Date()));
+
+    const timer = setInterval(() => setCurrentTime(format(new Date())), 1000);
+    return () => clearInterval(timer);
+  }, [type]);
+
+  const displayTitle = title ?? TITLE[type];
+  const displayInfo =
+    {
+      "": info,
+      point: <Tag type={type} theme="light" variant="general" points={info} />,
+      time: <span className={styles.curTime}>{currentTime}</span>,
+    }[type] ?? info;
+
+  return (
+    <div className={styles.boxHeaderInfo}>
+      <p className={styles.title}>{displayTitle}</p>
+      <div className={styles.info}>{displayInfo}</div>
+    </div>
+  );
+};
+
+export default BoxHeaderInfo;

--- a/src/components/BoxHeader/BoxHeaderInfo.jsx
+++ b/src/components/BoxHeader/BoxHeaderInfo.jsx
@@ -2,6 +2,9 @@ import React, { useEffect, useState } from "react";
 import styles from "./BoxHeaderInfo.module.css";
 import Tag from "../Tag/Tag";
 
+/**
+ * 고정 타이틀 출력할 상수 세팅
+ */
 const TITLE = {
   point: "현재까지 획득한 포인트",
   time: "현재 시간",
@@ -11,7 +14,7 @@ const BoxHeaderInfo = ({ type = "", title = null, info = null }) => {
   const [currentTime, setCurrentTime] = useState("");
 
   useEffect(() => {
-    if (type !== "time") return; // type 이 time 인 경우에만 useEffect 실행
+    if (type !== "time") return; // type 이 time 인 경우에만 useEffect 실행을 위한 early return
 
     const format = (date) => {
       const yyyy = date.getFullYear();
@@ -30,7 +33,7 @@ const BoxHeaderInfo = ({ type = "", title = null, info = null }) => {
     return () => clearInterval(timer);
   }, [type]);
 
-  const displayTitle = title ?? TITLE[type];
+  const displayTitle = title ?? TITLE[type]; // 전달 받은 title 값이 있을 경우 title 값을 우선 출력
   const displayInfo =
     {
       "": info,

--- a/src/components/BoxHeader/BoxHeaderInfo.module.css
+++ b/src/components/BoxHeader/BoxHeaderInfo.module.css
@@ -1,0 +1,27 @@
+.boxHeaderInfo {
+  width: 100%;
+}
+
+.boxHeaderInfo:not(:first-child) {
+  margin-top: 24px;
+}
+
+.boxHeaderInfo .title {
+  font: var(--text-18-regular);
+  color: var(--gray-500);
+}
+
+.boxHeaderInfo .info {
+  margin-top: 8px;
+  font: var(--text-18-medium);
+  color: var(--black);
+}
+
+.boxHeaderInfo .curTime {
+  padding: 8px 12px;
+  background-color: var(--white);
+  border: 1px solid var(--gray-300);
+  border-radius: 5em;
+  font: var(--text-16-medium);
+  color: var(--black);
+}

--- a/src/components/Tag/Tag.module.css
+++ b/src/components/Tag/Tag.module.css
@@ -20,6 +20,7 @@
 
 .tag-emoji {
   padding: 0.375rem 0.5rem;
+  color: var(--white);
 }
 
 .tag-light {
@@ -92,10 +93,11 @@
 
 .text-general {
   font: var(--text-16-regular);
-  color: var(--black);
+  color: var(--white);
 }
 
 .text-point-general {
   font: var(--text-16-medium);
+  color: var(--black);
   line-height: 1;
 }


### PR DESCRIPTION
## 개요

스터디상세, 습관, 집중 페이지 상단에 다른 데이터를 제공하지만 동일한 레이아웃의 UI 를 가진 부분을 확인하여
공통 컴포넌트로 빼서 조건에 따라 데이터만 바꿔서 출력하면 가져다쓰기 편할 것 같아서 작업을 진행

## 변경 사항

- components 에 BoxHeader 디렉터리 생성
- 디렉터리명에 Info 를 뺀 이유는... 추후에 시간적 여유가 된다면 
  상세, 습관, 집중 페이지의 상단 헤더부분 자체를 컴포넌트화 시킬 수 있을 것 같아서 디렉터리명은 BoxHeader 로 생성
- BoxHeaderInfo.jsx , BoxHeaderInfo.module.css 파일 생성

## 영향 범위

작업하면서 Tag 컴포넌트의 dark 테마일 때의 폰트 컬러를 수정

## 리뷰 요청 내용

각 페이지별로 만들 수도 있으나 UI 통일성(?)과 코드 재사용성(?)을 위해 컴포넌트화를 시키긴 했는데 
3곳에서 쓰이는 UI 인데... 컴포넌트 분리 기준이 3곳에서나 쓰이니까 컴포넌트로 빼는게 맞다로 봐야할지, 3곳에서밖에 안쓰이는데 굳이?가 맞는건지 컴포넌트로 분리하는 기준을 어떻게 둬야하는지 궁금합니다

- close #11 
