### PR TITLE
feat : 비밀번호 모달 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,18 +5,22 @@ import StudyDetailPage from "./pages/StudyDetailPage/StudyDetail";
 import StudyFormPage from "./pages/StudyFormPage/StudyForm";
 import HabitPage from "./pages/HabitPage/Habit";
 import FocusPage from "./pages/FocusPage/Focus";
+import Mordal from "./components/Modal/Modal";
 
 function App() {
   return (
-    <Routes>
-      <Route element={<AppLayout />}>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/studies/new" element={<StudyFormPage />} />
-        <Route path="/studies/:studyId" element={<StudyDetailPage />} />
-        <Route path="/studies/:studyId/habits" element={<HabitPage />} />
-        <Route path="/studies/:studyId/focus" element={<FocusPage />} />
-      </Route>
-    </Routes>
+    <>
+      <Routes>
+        <Route element={<AppLayout />}>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/studies/new" element={<StudyFormPage />} />
+          <Route path="/studies/:studyId" element={<StudyDetailPage />} />
+          <Route path="/studies/:studyId/habits" element={<HabitPage />} />
+          <Route path="/studies/:studyId/focus" element={<FocusPage />} />
+        </Route>
+      </Routes>
+      <Mordal />
+    </>
   );
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,7 @@ import StudyDetailPage from "./pages/StudyDetailPage/StudyDetail";
 import StudyFormPage from "./pages/StudyFormPage/StudyForm";
 import HabitPage from "./pages/HabitPage/Habit";
 import FocusPage from "./pages/FocusPage/Focus";
-import Mordal from "./components/Modal/Modal";
+import PasswordModal from "./pages/StudyDetailPage/components/PasswordModal/PasswordModal";
 
 function App() {
   return (
@@ -19,7 +19,7 @@ function App() {
           <Route path="/studies/:studyId/focus" element={<FocusPage />} />
         </Route>
       </Routes>
-      <Mordal />
+      <PasswordModal />
     </>
   );
 }

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -8,10 +8,10 @@ import Button from "../Button/Button";
 //confirmText : 확인 버튼 텍스트, 없으면 "수정 완료"로 들어감. (이 모달의 기본 목적이 습관 수정 모달이라서)
 //hasCancle : 취소 버튼 유무
 //hasExit : 나가기 버튼 유무
-const Mordal = ({
+const Modal = ({
   setShowModal,
   title = "모달 제목",
-  hasCancle = true,
+  hasCancel = true,
   hasExit = false,
   cancelText = "취소",
   confirmText = "수정 완료",
@@ -28,15 +28,17 @@ const Mordal = ({
             <button
               type="button"
               className={`${styles.exitBtn} ${styles.topBtn}`}
+              onClick={() => setShowModal(false)}
             >
               나가기
             </button>
           )}
         </div>
 
-        <div>{innerComponent}</div>
+        <div className={styles.innerComponent}>{innerComponent}</div>
+
         <div className={styles.modalButtons}>
-          {hasCancle && (
+          {hasCancel && (
             <div className={styles.modalButton}>
               <Button
                 variant="cancel"
@@ -63,6 +65,7 @@ const Mordal = ({
           <button
             type="button"
             className={`${styles.exitBtn} ${styles.bottomBtn}`}
+            onClick={() => setShowModal(false)}
           >
             나가기
           </button>
@@ -72,4 +75,4 @@ const Mordal = ({
   );
 };
 
-export default Mordal;
+export default Modal;

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -6,35 +6,52 @@ import Button from "../Button/Button";
 //innerComponent : 모달 내부에 들어갈 컴포넌트
 //cancelText : 취소 버튼 텍스트, 없으면 "취소"로 들어감.
 //confirmText : 확인 버튼 텍스트, 없으면 "수정 완료"로 들어감. (이 모달의 기본 목적이 습관 수정 모달이라서)
+//hasCancle : 취소 버튼 유무
+//hasExit : 나가기 버튼 유무
 const Mordal = ({
   setShowModal,
-  title,
+  title = "모달 제목",
+  hasCancle = true,
+  hasExit = false,
+  cancelText = "취소",
+  confirmText = "수정 완료",
   innerComponent,
-  confirmText,
-  cancelText,
   onClickConfirm,
   onClickCancel,
 }) => {
   return (
     <div className={styles.overlay}>
       <div className={styles.modalContainer}>
-        <h2 className={styles.modalTitle}>{title || "모달 제목"}</h2>
+        <div className={styles.headerContainer}>
+          <h2 className={styles.modalTitle}>{title}</h2>
+          {hasExit && (
+            <button
+              type="button"
+              className={`${styles.exitBtn} ${styles.topBtn}`}
+            >
+              나가기
+            </button>
+          )}
+        </div>
+
         <div>{innerComponent}</div>
         <div className={styles.modalButtons}>
-          <div className={styles.modalButton}>
-            <Button
-              variant="cancel"
-              label={cancelText || "취소"}
-              onClick={() => {
-                setShowModal(false);
-                onClickCancel && onClickCancel();
-              }}
-            />
-          </div>
+          {hasCancle && (
+            <div className={styles.modalButton}>
+              <Button
+                variant="cancel"
+                label={cancelText}
+                onClick={() => {
+                  setShowModal(false);
+                  onClickCancel && onClickCancel();
+                }}
+              />
+            </div>
+          )}
           <div className={styles.modalButton}>
             <Button
               variant="create"
-              label={confirmText || "수정 완료"}
+              label={confirmText}
               onClick={() => {
                 setShowModal(false);
                 onClickConfirm && onClickConfirm();
@@ -42,6 +59,14 @@ const Mordal = ({
             />
           </div>
         </div>
+        {hasExit && (
+          <button
+            type="button"
+            className={`${styles.exitBtn} ${styles.bottomBtn}`}
+          >
+            나가기
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -85,3 +85,7 @@
     display: block;
   }
 }
+
+.innerComponent {
+  width: 100%;
+}

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -46,3 +46,42 @@
 .modalButton {
   flex: 1;
 }
+
+.headerContainer {
+  position: relative;
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  align-items: center; /* 나가기 버튼을 중간에 두기 위함. */
+  justify-content: center;
+}
+.exitBtn {
+  color: #578246;
+  text-align: right;
+  font-family: Pretendard;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+}
+
+/* ── pc, 태블릿 (376px~) ── */
+.topBtn {
+  display: block; /* 굳이 필요없는 코드지만 이해를 돕기 위해 넣음 */
+  position: absolute;
+  right: 0;
+}
+.bottomBtn {
+  display: none;
+}
+
+/* ── 모바일 (~ 375px) ── */
+@media (max-width: 375px) {
+  .topBtn {
+    display: none;
+  }
+  .bottomBtn {
+    display: block;
+  }
+}

--- a/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.jsx
+++ b/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.jsx
@@ -1,0 +1,8 @@
+import React from "react";
+import styles from "./PasswordModal.module.css";
+
+const PasswordModal = () => {
+  return <div>PasswordModal</div>;
+};
+
+export default PasswordModal;

--- a/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.jsx
+++ b/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.jsx
@@ -66,7 +66,7 @@ const PasswordModal = ({
     }
   };
   return (
-    <div>
+    <div className={styles.pwModalContainer}>
       <Modal
         setShowModal={setShowModal}
         title={title}

--- a/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.jsx
+++ b/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.jsx
@@ -1,8 +1,86 @@
-import React from "react";
+import React, { useState } from "react";
 import styles from "./PasswordModal.module.css";
+import Modal from "../../../../components/Modal/Modal";
+import { verifyPassword } from "../../../../api/studies";
+import useToast from "../../../../hooks/useToast";
+import Toast from "../../../../components/Toast/Toast";
 
-const PasswordModal = () => {
-  return <div>PasswordModal</div>;
+//TODO: innerComponent 를 컴포넌트로 따로 빼기
+const PasswordModal = ({
+  setShowModal = () => {}, //이 모달을 보여줄지에 대한 상태. 이걸 넘겨주면, Modal에서 setShowModal(false)로 모달을 끌 수 있다.
+  studyId, //스터디 id (비밀번호 검증 API에 이용)
+  title, //스터디의 이름
+  confirmText, //습관, 집중, 수정, 삭제에 맞는 버튼 이름.
+  onPasswordSuccess = () => {}, //비밀번호가 일치했을 때 실행될 함수
+}) => {
+  const [password, setPassword] = useState("");
+  const [pwVisibleBtn, setPwVisibleBtn] = useState(false);
+
+  const { toast, showToast } = useToast();
+
+  //Modal 공통 컴포넌트 안에 넣을 것
+  const innerComponent = (
+    <div className={styles.innerComponent}>
+      <p className={styles.text}>권한이 필요합니다</p>
+      <div className={styles.inputElement}>
+        <label htmlFor="password-input" className={styles.label}>
+          비밀번호
+        </label>
+
+        <div className={styles.inputContainer}>
+          <input
+            type={pwVisibleBtn ? "text" : "password"}
+            id="password-input"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="비밀번호를 입력해 주세요"
+            className={`${styles.input} ${styles.pwInput}`}
+          />
+
+          <button
+            type="button"
+            className={pwVisibleBtn ? "ic visible" : "ic hidden"}
+            onClick={() => {
+              setPwVisibleBtn(!pwVisibleBtn);
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+
+  //버튼을 클릭했을 때, 비밀번호 검증 API를 실행하는 함수 (Modal에게 넘겨짐)
+  const onClickConfirmHandler = async () => {
+    if (!password.trim()) {
+      showToast("warning", "비밀번호를 입력해주세요!");
+      return;
+    }
+    try {
+      const res = await verifyPassword(studyId, { password });
+      console.log("비밀번호 검증 결과=>", res);
+      setShowModal(false); //비밀번호 일치하면 여기서 모달 닫음. (Modal에선 나가기 버튼 누를 시 모달 닫음)
+      showToast("success", "인증 되었습니다!");
+      onPasswordSuccess();
+    } catch (e) {
+      showToast("warning", "비밀번호가 일치하지 않습니다!");
+    }
+  };
+  return (
+    <div>
+      <Modal
+        setShowModal={setShowModal}
+        title={title}
+        hasCancel={false}
+        hasExit={true}
+        confirmText={confirmText}
+        innerComponent={innerComponent}
+        onClickConfirm={onClickConfirmHandler}
+      ></Modal>
+      <div className={styles.toast}>
+        {toast && <Toast type={toast.type} text={toast.text} />}
+      </div>
+    </div>
+  );
 };
 
 export default PasswordModal;

--- a/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.module.css
+++ b/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.module.css
@@ -1,0 +1,65 @@
+.innerComponent {
+  width: 100%;
+
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+.text {
+  color: var(--gray-gray_818181, #818181);
+  text-align: center;
+  font-family: Pretendard;
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+}
+.inputElement {
+  width: 100%;
+
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+}
+.inputContainer {
+  width: 100%;
+
+  position: relative;
+
+  display: flex;
+  align-items: center;
+}
+.inputContainer button {
+  width: 20.473px;
+  height: 18.065px;
+
+  position: absolute;
+  right: 20px;
+}
+.label {
+  color: var(--black, #414141);
+  font-family: Pretendard;
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+}
+.input {
+  padding: 15px 20px;
+
+  width: 100%;
+  height: 48px;
+
+  border-radius: 15px;
+  border: 1px solid var(--gray-300, #ddd);
+  background: #fff;
+}
+.pwInput {
+  padding-right: 50px; /*visible icon 자리를 위해*/
+}
+
+/*-----Toast------*/
+.toast {
+  z-index: 1000;
+}

--- a/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.module.css
+++ b/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.module.css
@@ -61,5 +61,10 @@
 
 /*-----Toast------*/
 .toast {
+  position: absolute;
   z-index: 1000;
+}
+
+.pwModalContainer {
+  position: relative;
 }

--- a/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.module.css
+++ b/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.module.css
@@ -6,7 +6,7 @@
   gap: 28px;
 }
 .text {
-  color: var(--gray-gray_818181, #818181);
+  color: var(--gray-500, #818181);
   text-align: center;
   font-family: Pretendard;
   font-size: 18px;


### PR DESCRIPTION
## 개요

비밀번호 모달을 구현했습니다.
비밀번호 모달이 쓰이는 곳 : **습관 페이지 접근, 집중 페이지 접근, 스터디 수정, 스터디 삭제**
구현 과정에서 `Modal` 공통 컴포넌트의 수정이 있었습니다.
비밀번호 모달의 자세한 사용 방식은 노션에 정리해두겠습니다.

## 변경 사항

- 폴더 구조 : `StudyDetailPage`폴더 안에, `components`폴더를 만들고, 그 하위에 `PasswordModal`을 작성함.
- `PasswordModal.jsx`: 비밀번호 모달 컴포넌트. `Modal`컴포넌트를 사용함.
  - Props
    - `setShowModal` : 모달을 보이게할지 설정하는 상태 함수.
    - `studyId`'
    - `title` : 모달 상단에 표시할 스터디 이름
    - `confirmText` : 모달 하단 버튼에 표시할 텍스트
    - `onPasswordSuccess` : 비밀번호 검증이 성공했을 시, 실행할 함수
- `PasswordModal.moudule.css`

## 스크린샷 (UI 변경 시)

**기본 UI**
<img width="590" height="441" alt="image" src="https://github.com/user-attachments/assets/df9f7689-be7a-415a-86a6-73e8203bd8d4" />

**비밀번호 미입력** 
<img width="736" height="697" alt="image" src="https://github.com/user-attachments/assets/e5d31908-f351-4662-8205-332b8326bf7f" />

**비밀번호 미일치 (인증 성공)**
<img width="664" height="697" alt="image" src="https://github.com/user-attachments/assets/cacaf2e4-faae-427d-87e0-0b6d98a7bd0a" />

**비밀번호 일치 (인증 성공)**
<img width="623" height="685" alt="image" src="https://github.com/user-attachments/assets/ab6a3c71-b9b0-4047-a4c6-e6d928795cd6" />



## 영향 범위

공통 컴포넌트 변경 : `Modal` - '나가기'버튼 추가, Props 기본값 변경, Props에 취소버튼 여부 변수 추가. 


## 관련 이슈

- close #18 
