### PR TITLE
feat: 오늘의 집중 페이지에 집중 세션 API 연동 

### DIFF
--- a/src/api/focus.js
+++ b/src/api/focus.js
@@ -2,12 +2,12 @@ import api from "./instance";
 
 // 집중 세션 조회
 export const getFocusSession = (studyId) =>
-  api.get(`/studies/${studyId}/focus`);
+  api.get(`/studies/${studyId}/focus-sessions`);
 
 // 집중 세션 생성 (시작)
 export const createFocusSession = (studyId, body) =>
-  api.post(`/studies/${studyId}/focus`, body);
+  api.post(`/studies/${studyId}/focus-sessions`, body);
 
 // 집중 세션 상태 변경 (일시정지/다시시작/종료)
 export const updateFocusSession = (studyId, sessionId, body) =>
-  api.patch(`/studies/${studyId}/focus/${sessionId}`, body);
+  api.patch(`/studies/${studyId}/focus-sessions/${sessionId}`, body);

--- a/src/constants/errorMessages.js
+++ b/src/constants/errorMessages.js
@@ -4,7 +4,7 @@ export const ERROR_MESSAGES = {
   [ERROR_CODES.NOT_FOUND]: "해당 리소스를 찾을 수 없습니다.",
   [ERROR_CODES.VALIDATION_ERROR]: "입력값을 다시 확인해주세요.",
   [ERROR_CODES.UNAUTHORIZED]: "스터디 비밀번호 인증이 필요합니다.",
-  [ERROR_CODES.CONFLICT]: "이미 존재하는 정보합니다.",
+  [ERROR_CODES.CONFLICT]: "이미 존재하는 정보입니다.",
   [ERROR_CODES.INTERNAL_ERROR]:
     "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
 };

--- a/src/hooks/useTimer.js
+++ b/src/hooks/useTimer.js
@@ -28,12 +28,12 @@ function useTimer(studyId) {
 
   const { toast, showToast } = useToast();
 
+  // 타이머 완료 처리
   const handleComplete = useCallback(async () => {
     try {
       const res = await updateFocusSession(studyId, sessionIdRef.current, {
-        status: "completed",
+        action: TIMER_STATUS.COMPLETED,
       });
-      console.log(res);
 
       const { data } = res.data;
 
@@ -46,6 +46,58 @@ function useTimer(studyId) {
     }
   }, [showToast, studyId]);
 
+  // 페이지 진입 시 세션 조회
+  useEffect(() => {
+    const fetchSession = async () => {
+      try {
+        const res = await getFocusSession(studyId);
+
+        const { data } = res.data;
+        if (!data) return;
+
+        sessionIdRef.current = data.id;
+        setEarnedPoint(data.earnedPoint ?? 0);
+
+        if (data.status === TIMER_STATUS.RUNNING) {
+          // endTime 기준으로 남은 시간 계산
+          const remaining = Math.ceil(
+            (new Date(data.endTime).getTime() - Date.now()) / 1000,
+          );
+
+          if (remaining <= 0) {
+            // 서버에선 running인데 시간이 이미 지난 경우
+            handleComplete();
+            return;
+          }
+
+          endTimeRef.current = new Date(data.endTime);
+          setTimeLeft(remaining);
+          setTimerStatus(TIMER_STATUS.RUNNING);
+        } else if (data.status === TIMER_STATUS.PAUSED) {
+          // paused: endTime - pausedAt 으로 남은 시간 계산
+          const remaining = Math.ceil(
+            (new Date(data.endTime).getTime() -
+              new Date(data.pausedAt).getTime()) /
+              1000,
+          );
+
+          await updateFocusSession(studyId, sessionIdRef.current, {
+            action: TIMER_STATUS.RUNNING,
+          });
+
+          endTimeRef.current = new Date(Date.now() + remaining * 1000);
+          setTimeLeft(remaining > 0 ? remaining : 0);
+          setTimerStatus(TIMER_STATUS.RUNNING);
+        }
+      } catch (e) {
+        showToast("warning", e.userMessage);
+      }
+    };
+
+    fetchSession();
+  }, [studyId, handleComplete, showToast]);
+
+  // 타이머 실행
   useEffect(() => {
     if (timerStatus !== TIMER_STATUS.RUNNING) {
       clearInterval(intervalIdRef.current);
@@ -79,7 +131,6 @@ function useTimer(studyId) {
       const res = await createFocusSession(studyId, {
         durationMin: DURATION_MIN,
       });
-      console.log(res);
 
       const { data } = res.data;
 
@@ -96,9 +147,8 @@ function useTimer(studyId) {
   const pause = async () => {
     try {
       const res = await updateFocusSession(studyId, sessionIdRef.current, {
-        action: "paused",
+        action: TIMER_STATUS.PAUSED,
       });
-      console.log(res);
 
       const { data } = res.data;
 
@@ -114,9 +164,8 @@ function useTimer(studyId) {
       const requestedAt = Date.now();
 
       const res = await updateFocusSession(studyId, sessionIdRef.current, {
-        action: "running",
+        action: TIMER_STATUS.RUNNING,
       });
-      console.log(res);
 
       const { data } = res.data;
 

--- a/src/hooks/useTimer.js
+++ b/src/hooks/useTimer.js
@@ -1,4 +1,9 @@
 import { useState, useEffect, useRef, useCallback } from "react";
+import {
+  getFocusSession,
+  createFocusSession,
+  updateFocusSession,
+} from "../api/focus";
 import useToast from "./useToast";
 
 export const TIMER_STATUS = {
@@ -10,7 +15,7 @@ export const TIMER_STATUS = {
 
 const DURATION_MIN = 25; // 타이머 시간 초기값
 
-function useTimer() {
+function useTimer(studyId) {
   const initialSeconds = DURATION_MIN * 60;
 
   const [timerStatus, setTimerStatus] = useState(TIMER_STATUS.IDLE);
@@ -19,6 +24,7 @@ function useTimer() {
 
   const endTimeRef = useRef(null); // Date.now와 종료 시각을 기준으로 남은 시간 계산
   const intervalIdRef = useRef(null); // 현재 실행 중인 Interval의 ID
+  const sessionIdRef = useRef(null);
 
   const { toast, showToast } = useToast();
 
@@ -60,10 +66,21 @@ function useTimer() {
   }, [timerStatus, handleComplete]);
 
   const start = async () => {
-    // 현재 시간과 설정 시간을 더해 종료 시각 설정
-    endTimeRef.current = new Date(Date.now() + DURATION_MIN * 60 * 1000);
-    setTimeLeft(DURATION_MIN * 60);
-    setTimerStatus(TIMER_STATUS.RUNNING);
+    try {
+      const res = await createFocusSession(studyId, {
+        durationMin: DURATION_MIN,
+      });
+      console.log(res);
+
+      const { data } = res.data;
+
+      sessionIdRef.current = data.id;
+      endTimeRef.current = new Date(data.endTime);
+      setTimeLeft(initialSeconds);
+      setTimerStatus(data.status);
+    } catch (e) {
+      showToast("warning", e.userMessage);
+    }
   };
 
   // 일시 정지 (interval만 멈추고 endTimeRef 유지)

--- a/src/hooks/useTimer.js
+++ b/src/hooks/useTimer.js
@@ -29,13 +29,22 @@ function useTimer(studyId) {
   const { toast, showToast } = useToast();
 
   const handleComplete = useCallback(async () => {
-    const pointResult = 100; // API 연동 후 실제 획득한 포인트로 업데이트 예정
+    try {
+      const res = await updateFocusSession(studyId, sessionIdRef.current, {
+        status: "completed",
+      });
+      console.log(res);
 
-    setEarnedPoint(pointResult);
-    setTimerStatus(TIMER_STATUS.COMPLETED);
+      const { data } = res.data;
 
-    showToast("success", "포인트를 획득했습니다!", pointResult);
-  }, [showToast]);
+      const pointResult = data.earnedPoint ?? 0;
+      setEarnedPoint(pointResult);
+      setTimerStatus(data.status);
+      showToast("success", "포인트를 획득했습니다!", pointResult);
+    } catch (e) {
+      showToast("warning", e.userMessage);
+    }
+  }, [showToast, studyId]);
 
   useEffect(() => {
     if (timerStatus !== TIMER_STATUS.RUNNING) {
@@ -84,15 +93,39 @@ function useTimer(studyId) {
   };
 
   // 일시 정지 (interval만 멈추고 endTimeRef 유지)
-  const pause = () => {
-    setTimerStatus(TIMER_STATUS.PAUSED);
-    showToast("warning", "집중이 중단되었습니다.");
+  const pause = async () => {
+    try {
+      const res = await updateFocusSession(studyId, sessionIdRef.current, {
+        action: "paused",
+      });
+      console.log(res);
+
+      const { data } = res.data;
+
+      setTimerStatus(data.status);
+      showToast("warning", "집중이 중단되었습니다.");
+    } catch (e) {
+      showToast("warning", e.userMessage);
+    }
   };
 
   const resume = async () => {
-    // 일시정지 시점의 남은 시간을 현재 시각에 더해 종료 시각을 재설정
-    endTimeRef.current = new Date(Date.now() + timeLeft * 1000);
-    setTimerStatus(TIMER_STATUS.RUNNING);
+    try {
+      const requestedAt = Date.now();
+
+      const res = await updateFocusSession(studyId, sessionIdRef.current, {
+        action: "running",
+      });
+      console.log(res);
+
+      const { data } = res.data;
+
+      const elapsed = Date.now() - requestedAt;
+      endTimeRef.current = new Date(new Date(data.endTime).getTime() - elapsed);
+      setTimerStatus(data.status);
+    } catch (e) {
+      showToast("warning", e.userMessage);
+    }
   };
 
   return {

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -1,4 +1,6 @@
+import { useState, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { getStudyDetail } from "../../api/studies";
 import BoxHeaderInfo from "../../components/BoxHeader/BoxHeaderInfo";
 import NavButton from "../../components/NavButton/NavButton";
 import Toast from "../../components/Toast/Toast";
@@ -9,6 +11,22 @@ import styles from "./Focus.module.css";
 function Focus() {
   const navigate = useNavigate();
   const { studyId } = useParams();
+  const [study, setStudy] = useState(null);
+
+  useEffect(() => {
+    const fetchStudy = async () => {
+      try {
+        const res = await getStudyDetail(studyId);
+        const { data } = res.data;
+        console.log(data);
+        setStudy(data);
+      } catch (e) {
+        console.error(e);
+      }
+    };
+
+    fetchStudy();
+  }, [studyId]);
 
   const {
     timerStatus,
@@ -34,7 +52,9 @@ function Focus() {
 
       <div className={styles.header}>
         <div className={styles.headerTop}>
-          <h2 className={styles.title}>연우의 개발공장</h2>
+          <h2 className={styles.title}>
+            {study?.nickname}의 {study?.title}
+          </h2>
           <div className={styles.nav}>
             <NavButton
               label="오늘의 습관"

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -19,7 +19,7 @@ function Focus() {
     pause,
     resume,
     toast,
-  } = useTimer();
+  } = useTimer(studyId);
 
   const isRunning = timerStatus === TIMER_STATUS.RUNNING;
   const isPaused = timerStatus === TIMER_STATUS.PAUSED;


### PR DESCRIPTION
## 개요
오늘의 집중 페이지에 집중 세션 관련 API들을 연동했습니다.
페이지 진입 시 진행 중인 세션을 조회하고, 타이머 시작 / 일시정지 / 재시작 / 종료 시 각 상태에 맞는 API가 호출되도록 수정했습니다.
또한 스터디 정보(title, nickname)를 조회하고 화면에 표시하도록 수정했습니다

## 변경 사항
- 집중 세션 조회 API 연동 (페이지 진입 시 진행 중 세션이 있다면 복원 → 타이머 진행)
- 집중 세션 생성 API 연동 (타이머 시작)
- 집중 상태 변경 API 연동 (일시정지 / 재시작 / 종료)
- 서버 endTime 기준으로 타이머 동작하도록 로직 수정
- 스터디 정보(title, nickname) 조회 추가

## 영향 범위
- useTimer 커스텀 훅 동작 로직 변경

## 관련 이슈
- close #17

---
## 코드리뷰 요청 사항
### 요청 내용
멘토님 안녕하세요. 오늘의 집중 타이머 기능을 구현하면서 이런 구조가 적절한지 의문이 들었습니다. 전반적인 방향성에 대해 조언 주시면 감사하겠습니다.

### 현재 구조
- Focus 페이지: UI 렌더링 + 스터디 정보 조회
- useTimer 커스텀 훅: 타이머 상태 관리 + interval 관리 + 집중 세션 API 호출
- TIMER_STATUS 객체로 상태 enum 관리
- 서버 endTime 기준으로 타이머 동기화

### 고민한 부분
1. useTimer 훅의 책임 범위
- 현재 `useTimer` 훅 내부에서 세션 조회/생성/상태 변경  API 호출, interval 관리, endTime 기반 타이머 계산, toast 메시지 처리를 처리하고 있습니다.
- 동작에는 문제가 없지만 `useTimer` 훅에 책임이 과중된 느낌이라 역할 분리를 고려하고 있습니다. 그런데 타이머 로직과 API 호출, 상태 관리가 서로 밀접하게 연결되어 있어서 어느 수준까지 분리하는 것이 적절한지 기준이 궁금합니다.

2. TIMER_STATUS 객체로 타이머 상태 관리 방식
- 현재 문자열 하드코딩 대신 아래와 같이 객체로 상태를 관리하고 있습니다.
```js
export const TIMER_STATUS = {
  IDLE: "idle",
  RUNNING: "running",
  PAUSED: "paused",
  COMPLETED: "completed",
};
```
- 문자열을 직접 사용하는 경우 오타나 누락 등 실수가 발생하기 쉽고, 변경 발생 시 수정 범위가 넓어지므로 위와 같은 방식을 선택했습니다.
- 이 방식이 일반적으로 사용하는 패턴인지, 혹은 더 적절한 방법이 있는지 궁금합니다.

- 또한 현재 컴포넌트에서 아래처럼 파생 상태를 만들고 있습니다.
```js
const isRunning = timerStatus === TIMER_STATUS.RUNNING;
const isPaused = timerStatus === TIMER_STATUS.PAUSED;
const isCompleted = timerStatus === TIMER_STATUS.COMPLETED;
const isIdle = timerStatus === TIMER_STATUS.IDLE;
```
- 이런 파생 상태들을 훅에서 제공하는 것이 더 좋은지, 컴포넌트에서 처리하는 현재 방식이 괜찮은지도 궁금합니다.

3. 시간 계산 책임
- 현재는 서버에서 endTime을 내려주고 클라이언트에서 남은 시간을 계산하는 구조로 구현했습니다.
- pause/resume 시점 보정, 네트워크 지연 보정, 클라이언트 시간 기준 문제 등을 고려해야 해서 로직이 다소 복잡한 상태입니다.
- 타이머 로직에서 시간 계산 책임을 서버에 두는 것이 나을지, 현재처럼 혼합 구조로 두는 것이 나을지 고민됩니다.일반적으로 어떤 패턴을 사용하는지, 구조를 단순하게 유지하려면 어떤 방식이 적절할지 조언 부탁드립니다.

## 코드 리뷰 시 참고사항
- 타이머 시간이 25분으로 고정되어 있는데, 추후에는 사용자가 타이머 시간을 설정할 수 있는 기능을 넣을 예정입니다.
- 페이지 진입 시 paused/running 상태 세션이 조회되면, 타이머를 자동 재시작하도록 구현했습니다. 추후에는 무조건 재시작하는 것이 아니라, 사용자가 재시작 여부를 결정하도록 변경할 예정입니다.
- 페이지 진입 시 스터디 정보 조회 API를 호출해 초기 렌더링 지연이 발생하고 있습니다. 해당 스터디 정보는 여러 페이지에서 사용되므로 추후에는 전역 상태로 관리할 예정입니다.
