### PR TITLE
feat : 스터디 상세 - 수정/삭제/공유 버튼 동작 구현

### DIFF
--- a/src/pages/StudyDetailPage/StudyDetail.jsx
+++ b/src/pages/StudyDetailPage/StudyDetail.jsx
@@ -4,8 +4,9 @@ import { useNavigate, useParams } from "react-router-dom";
 import Tag from "../../components/Tag/Tag";
 import BoxHeaderInfo from "../../components/BoxHeader/BoxHeaderInfo";
 import NavButton from "../../components/NavButton/NavButton";
-import { getStudyDetail } from "../../api/studies";
+import { deleteStudy, getStudyDetail } from "../../api/studies";
 import PasswordModal from "./components/PasswordModal/PasswordModal";
+import Popup from "../../components/Popup/Popup";
 
 const StudyDetail = () => {
   const { id = 1 } = useParams();
@@ -27,33 +28,73 @@ const StudyDetail = () => {
 
   /* 공유/삭제/수정 버튼 관련 상태 변수 */
   const [showModal, setShowModal] = useState(false); //비밀번호 모달을 보여주는 상태
-
-  const [formType, setFormType] = useState(""); //생성/수정의 경우, 비밀번호 인증 성공 시 실행할 form의 type. (create, modify)
+  const [showDeletePopup, setShowDeletePopup] = useState(false); //정말 삭제하시겠습니까? 팝업.
   const [confirmText, setConfirmText] = useState(""); //버튼마다 비밀번호 모달 내 버튼명이 다르므로, 여기에 저장해서 사용.
-  //근데 이건 현재 페이지의 UI로 보이는 게 아니라서, 그냥 let 변수로 관리하는 게 더 부하 적을 것이라 판단.
+  const [pwType, setPwType] = useState("");
+
   /* 공유/수정/삭제 버튼 클릭 핸들러 */
   const onClickModify = () => {
+    //먼저 세션 확인!!!!! 세션에 없다면 비밀번호 모달 실행
     //비밀번호 체크 모달 -> 비밀번호 일치할 시 -> 수정 페이지로 Link
-    setFormType("modify");
+    setPwType("modify");
     setConfirmText("수정하러 가기");
     setShowModal(true);
   };
-  const onClickDelete = () => {};
+  const onClickDelete = () => {
+    setPwType("delete");
+    setConfirmText("삭제하기");
+    setShowModal(true);
+  };
   const onClickSharing = () => {};
+
+  //비밀번호 인증 성공 시 실행할 함수.
+  const onPasswordSuccess = () => {
+    switch (pwType) {
+      case "modify":
+        navigate(`/studies/new`, {
+          state: { type: "modify", study },
+        });
+        break;
+      case "delete":
+        //진짜로 삭제할거냔 거 표시하기 -> 취소버튼 누르면, 원래 상세 페이지로. 확인 버튼 누르면 -> delete api 호출
+        setShowDeletePopup(true);
+        break;
+      //TODO: 여기에 집중 진입, 습관 진입 시의 코드도 적을 수 있을 것 같습니다!
+      default:
+        break;
+    }
+  };
+
+  //삭제 버튼 -> 비밀번호 입력 -> 인증 성공 -> 정말 삭제하시겠습니까? 네 -> 하고나서 실행 될 함수.
+  const handleDelete = async () => {
+    try {
+      await deleteStudy(id);
+    } catch (e) {
+      //TODO: 삭제 실패 시 toast 띄우기
+      console.log("삭제 실패 =>", e);
+    }
+    setShowDeletePopup(false);
+  };
 
   return (
     <section className={styles.box}>
-      {showModal && study && (
-        <PasswordModal
-          setShowModal={setShowModal}
-          studyId={id}
-          title={study.title}
-          confirmText={confirmText}
-          onPasswordSuccess={() => {
-            navigate(`/studies/new`, {
-              state: { type: formType, study },
-            });
-          }}
+      {showModal &&
+        study && ( //비밀번호 모달 띄우기
+          <PasswordModal
+            setShowModal={setShowModal}
+            studyId={id}
+            title={study.title}
+            confirmText={confirmText}
+            onPasswordSuccess={onPasswordSuccess}
+          />
+        )}
+      {showDeletePopup && ( //정말 삭제하시겠습니까? 팝업
+        <Popup
+          setShowPopup={setShowDeletePopup}
+          hasCancel={true}
+          message="정말 삭제하시겠습니까?"
+          onClickConfirm={handleDelete}
+          onClickCancel={() => setShowDeletePopup(false)}
         />
       )}
       <div className={styles.boxHeader}>

--- a/src/pages/StudyDetailPage/StudyDetail.jsx
+++ b/src/pages/StudyDetailPage/StudyDetail.jsx
@@ -12,7 +12,7 @@ import Toast from "../../components/Toast/Toast";
 import useToast from "../../hooks/useToast";
 
 const StudyDetail = () => {
-  const { id = 1 } = useParams();
+  const { id } = useParams();
   const [study, setStudy] = useState(null); //가져온 스터디 객체를 저장할 변수
   const navigate = useNavigate();
 
@@ -30,9 +30,10 @@ const StudyDetail = () => {
   }, [id]);
 
   /* 공유/삭제/수정 버튼 관련 상태 변수 */
-  const [showPwModal, setShowPwModal] = useState(false); //비밀번호 모달을 보여주는 상태
-  const [showDeletePopup, setShowDeletePopup] = useState(false); //정말 삭제하시겠습니까? 팝업.
-  const [showSharingModal, setShowSharingModal] = useState(false);
+  const [showPwModal, setShowPwModal] = useState(false); //비밀번호 모달
+
+  const [showDeletePopup, setShowDeletePopup] = useState(false); //삭제 재확인 팝업
+  const [showSharingModal, setShowSharingModal] = useState(false); //공유 모달
 
   const [confirmText, setConfirmText] = useState(""); //버튼마다 비밀번호 모달 내 버튼명이 다르므로, 여기에 저장해서 사용.
   const [pwType, setPwType] = useState(""); //삭제/수정 중 무엇인지 기록하는 용도
@@ -72,6 +73,18 @@ const StudyDetail = () => {
       //TODO: 여기에 집중 진입, 습관 진입 시의 코드도 적을 수 있을 것 같습니다!
       default:
         break;
+    }
+  };
+
+  //공유 모달에서 '복사하기'버튼 클릭 시 실행할 함수
+  const onHandleSharing = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      console.log("복사 성공.");
+      showToast("success", "복사되었습니다!");
+    } catch (e) {
+      console.log("복사 실패=>", e);
+      showToast("warning", "복사에 실패했습니다.");
     }
   };
 
@@ -115,16 +128,7 @@ const StudyDetail = () => {
           setShowModal={setShowSharingModal}
           title={study.title}
           url={window.location.href}
-          onClickConfirm={async () => {
-            try {
-              await navigator.clipboard.writeText(window.location.href);
-              console.log("복사 성공.");
-              showToast("success", "복사되었습니다!");
-            } catch (e) {
-              console.log("복사 실패=>", e);
-              showToast("warning", "복사에 실패했습니다.");
-            }
-          }}
+          onClickConfirm={onHandleSharing}
         />
       )}
       <div className={styles.boxHeader}>

--- a/src/pages/StudyDetailPage/StudyDetail.jsx
+++ b/src/pages/StudyDetailPage/StudyDetail.jsx
@@ -8,6 +8,8 @@ import { deleteStudy, getStudyDetail } from "../../api/studies";
 import PasswordModal from "./components/PasswordModal/PasswordModal";
 import Popup from "../../components/Popup/Popup";
 import SharingModal from "./components/SharingModal/SharingModal";
+import Toast from "../../components/Toast/Toast";
+import useToast from "../../hooks/useToast";
 
 const StudyDetail = () => {
   const { id = 1 } = useParams();
@@ -34,6 +36,9 @@ const StudyDetail = () => {
 
   const [confirmText, setConfirmText] = useState(""); //버튼마다 비밀번호 모달 내 버튼명이 다르므로, 여기에 저장해서 사용.
   const [pwType, setPwType] = useState(""); //삭제/수정 중 무엇인지 기록하는 용도
+
+  //토스트
+  const { toast, showToast } = useToast();
 
   /* 공유/수정/삭제 버튼 클릭 핸들러 */
   const onClickModify = () => {
@@ -75,8 +80,9 @@ const StudyDetail = () => {
     try {
       await deleteStudy(id);
       navigate("/");
+      showToast("success", "삭제되었습니다");
     } catch (e) {
-      //TODO: 삭제 실패 시 toast 띄우기
+      showToast("warning", "삭제에 실패했습니다");
       console.log("삭제 실패 =>", e);
     }
     setShowDeletePopup(false);
@@ -84,6 +90,7 @@ const StudyDetail = () => {
 
   return (
     <section className={styles.box}>
+      {toast && <Toast type={toast.type} text={toast.text} />}
       {showPwModal &&
         study && ( //비밀번호 모달 띄우기
           <PasswordModal
@@ -112,10 +119,10 @@ const StudyDetail = () => {
             try {
               await navigator.clipboard.writeText(window.location.href);
               console.log("복사 성공.");
-              //TODO: 복사 성공 토스트 띄우기
+              showToast("success", "복사되었습니다!");
             } catch (e) {
-              console.log("복사 실패");
-              //TODO: 복사 실패 토스트 띄우기
+              console.log("복사 실패=>", e);
+              showToast("warning", "복사에 실패했습니다.");
             }
           }}
         />

--- a/src/pages/StudyDetailPage/StudyDetail.jsx
+++ b/src/pages/StudyDetailPage/StudyDetail.jsx
@@ -1,28 +1,73 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import styles from "./StudyDetail.module.css";
 import { useNavigate, useParams } from "react-router-dom";
 import Tag from "../../components/Tag/Tag";
 import BoxHeaderInfo from "../../components/BoxHeader/BoxHeaderInfo";
 import NavButton from "../../components/NavButton/NavButton";
+import { getStudyDetail } from "../../api/studies";
+import PasswordModal from "./components/PasswordModal/PasswordModal";
 
 const StudyDetail = () => {
-  const { id } = useParams();
+  const { id = 1 } = useParams();
+  const [study, setStudy] = useState(null); //가져온 스터디 객체를 저장할 변수
   const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchStudy = async () => {
+      try {
+        const res = await getStudyDetail(id);
+        setStudy(res.data.data);
+        console.log(res.data.data);
+      } catch (error) {
+        console.error(`데이터 조회 실패: ${error}`);
+      }
+    };
+    fetchStudy();
+  }, []);
+
+  /* 공유/삭제/수정 버튼 관련 상태 변수 */
+  const [showModal, setShowModal] = useState(false); //비밀번호 모달을 보여주는 상태
+
+  const [formType, setFormType] = useState(""); //생성/수정의 경우, 비밀번호 인증 성공 시 실행할 form의 type. (create, modify)
+  const [confirmText, setConfirmText] = useState(""); //버튼마다 비밀번호 모달 내 버튼명이 다르므로, 여기에 저장해서 사용.
+  //근데 이건 현재 페이지의 UI로 보이는 게 아니라서, 그냥 let 변수로 관리하는 게 더 부하 적을 것이라 판단.
+  /* 공유/수정/삭제 버튼 클릭 핸들러 */
+  const onClickModify = () => {
+    //비밀번호 체크 모달 -> 비밀번호 일치할 시 -> 수정 페이지로 Link
+    setFormType("modify");
+    setConfirmText("수정하러 가기");
+    setShowModal(true);
+  };
+  const onClickDelete = () => {};
+  const onClickSharing = () => {};
 
   return (
     <section className={styles.box}>
+      {showModal && study && (
+        <PasswordModal
+          setShowModal={setShowModal}
+          studyId={id}
+          title={study.title}
+          confirmText={confirmText}
+          onPasswordSuccess={() => {
+            navigate(`/studies/new`, {
+              state: { type: formType, study },
+            });
+          }}
+        />
+      )}
       <div className={styles.boxHeader}>
         <div className={styles.headerTop}>
           <div className={styles.management}>
             <ul>
               <li>
-                <button>공유하기</button>
+                <button onClick={onClickSharing}>공유하기</button>
               </li>
               <li>
-                <button>수정하기</button>
+                <button onClick={onClickModify}>수정하기</button>
               </li>
               <li>
-                <button>스터디 삭제하기</button>
+                <button onClick={onClickDelete}>스터디 삭제하기</button>
               </li>
             </ul>
           </div>

--- a/src/pages/StudyDetailPage/StudyDetail.jsx
+++ b/src/pages/StudyDetailPage/StudyDetail.jsx
@@ -7,6 +7,7 @@ import NavButton from "../../components/NavButton/NavButton";
 import { deleteStudy, getStudyDetail } from "../../api/studies";
 import PasswordModal from "./components/PasswordModal/PasswordModal";
 import Popup from "../../components/Popup/Popup";
+import SharingModal from "./components/SharingModal/SharingModal";
 
 const StudyDetail = () => {
   const { id = 1 } = useParams();
@@ -24,13 +25,15 @@ const StudyDetail = () => {
       }
     };
     fetchStudy();
-  }, []);
+  }, [id]);
 
   /* 공유/삭제/수정 버튼 관련 상태 변수 */
-  const [showModal, setShowModal] = useState(false); //비밀번호 모달을 보여주는 상태
+  const [showPwModal, setShowPwModal] = useState(false); //비밀번호 모달을 보여주는 상태
   const [showDeletePopup, setShowDeletePopup] = useState(false); //정말 삭제하시겠습니까? 팝업.
+  const [showSharingModal, setShowSharingModal] = useState(false);
+
   const [confirmText, setConfirmText] = useState(""); //버튼마다 비밀번호 모달 내 버튼명이 다르므로, 여기에 저장해서 사용.
-  const [pwType, setPwType] = useState("");
+  const [pwType, setPwType] = useState(""); //삭제/수정 중 무엇인지 기록하는 용도
 
   /* 공유/수정/삭제 버튼 클릭 핸들러 */
   const onClickModify = () => {
@@ -38,14 +41,16 @@ const StudyDetail = () => {
     //비밀번호 체크 모달 -> 비밀번호 일치할 시 -> 수정 페이지로 Link
     setPwType("modify");
     setConfirmText("수정하러 가기");
-    setShowModal(true);
+    setShowPwModal(true);
   };
   const onClickDelete = () => {
     setPwType("delete");
     setConfirmText("삭제하기");
-    setShowModal(true);
+    setShowPwModal(true);
   };
-  const onClickSharing = () => {};
+  const onClickSharing = () => {
+    setShowSharingModal(true);
+  };
 
   //비밀번호 인증 성공 시 실행할 함수.
   const onPasswordSuccess = () => {
@@ -65,10 +70,11 @@ const StudyDetail = () => {
     }
   };
 
-  //삭제 버튼 -> 비밀번호 입력 -> 인증 성공 -> 정말 삭제하시겠습니까? 네 -> 하고나서 실행 될 함수.
+  //삭제해주는 함수. 삭제 버튼 -> 비밀번호 입력 -> 인증 성공 -> 정말 삭제하시겠습니까? 네 -> 하고나서 실행 될 함수.
   const handleDelete = async () => {
     try {
       await deleteStudy(id);
+      navigate("/");
     } catch (e) {
       //TODO: 삭제 실패 시 toast 띄우기
       console.log("삭제 실패 =>", e);
@@ -78,10 +84,10 @@ const StudyDetail = () => {
 
   return (
     <section className={styles.box}>
-      {showModal &&
+      {showPwModal &&
         study && ( //비밀번호 모달 띄우기
           <PasswordModal
-            setShowModal={setShowModal}
+            setShowModal={setShowPwModal}
             studyId={id}
             title={study.title}
             confirmText={confirmText}
@@ -95,6 +101,23 @@ const StudyDetail = () => {
           message="정말 삭제하시겠습니까?"
           onClickConfirm={handleDelete}
           onClickCancel={() => setShowDeletePopup(false)}
+        />
+      )}
+      {showSharingModal && study && (
+        <SharingModal
+          setShowModal={setShowSharingModal}
+          title={study.title}
+          url={window.location.href}
+          onClickConfirm={async () => {
+            try {
+              await navigator.clipboard.writeText(window.location.href);
+              console.log("복사 성공.");
+              //TODO: 복사 성공 토스트 띄우기
+            } catch (e) {
+              console.log("복사 실패");
+              //TODO: 복사 실패 토스트 띄우기
+            }
+          }}
         />
       )}
       <div className={styles.boxHeader}>

--- a/src/pages/StudyDetailPage/components/SharingModal/SharingModal.jsx
+++ b/src/pages/StudyDetailPage/components/SharingModal/SharingModal.jsx
@@ -1,7 +1,20 @@
 import React from "react";
+import Modal from "../../../../components/Modal/Modal";
 
-const SharingModal = () => {
-  return <div>SharingModal</div>;
+const SharingModal = ({ setShowModal, title, url, onClickConfirm }) => {
+  return (
+    <div>
+      <Modal
+        setShowModal={setShowModal}
+        title={title}
+        hasCancel={false}
+        hasExit={true}
+        confirmText="복사하기"
+        innerComponent={<p>{url}</p>}
+        onClickConfirm={onClickConfirm}
+      />
+    </div>
+  );
 };
 
 export default SharingModal;

--- a/src/pages/StudyDetailPage/components/SharingModal/SharingModal.jsx
+++ b/src/pages/StudyDetailPage/components/SharingModal/SharingModal.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const SharingModal = () => {
+  return <div>SharingModal</div>;
+};
+
+export default SharingModal;

--- a/src/pages/StudyFormPage/StudyForm.jsx
+++ b/src/pages/StudyFormPage/StudyForm.jsx
@@ -10,7 +10,7 @@ import desk1 from "../../assets/images/desk1.jpg";
 import desk2 from "../../assets/images/desk2.jpg";
 import tile from "../../assets/images/tile.jpg";
 import leaf from "../../assets/images/leaf.jpg";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 //type
 //- modify : 수정을 위한 ui,
@@ -18,11 +18,22 @@ import { useNavigate } from "react-router-dom";
 //  기존 스터디 객체를 상태변수의 기본 값으로 설정. create면 빈 객체니까 자동으로 빈 값으로 들어갈 것.
 //- create : 생성을 위한 ui
 function StudyForm({ type = "create", study = {} }) {
+  //일단 지금은 navigate로만 접근하기 때문에, 실질적으로 props는 필요가 없음. 그러나 혹시 모르니 남겨둔다..
+  //만약 다른 곳에서 얘를 컴포넌트로 사용하게 된다면..그러면 필요한..
+  useEffect(() => {
+    console.log("type=>", type);
+    console.log("study=>", study);
+  }, []);
+
+  const location = useLocation();
+  type = location.state.type;
+  study = location.state.study;
+
   const navigate = useNavigate();
   //input 상태 변수들
-  const [nickname, setNickname] = useState(study.nickname || "");
-  const [title, setTitle] = useState(study.title || "");
-  const [description, setDescription] = useState(study.description || "");
+  const [nickname, setNickname] = useState(study?.nickname || "");
+  const [title, setTitle] = useState(study?.title || "");
+  const [description, setDescription] = useState(study?.description || "");
   const [password, setPassword] = useState(""); //비밀번호는 빈 값으로 둠! (보통 그렇지 않나;;)
   const [checkPassword, setCheckPassword] = useState("");
 
@@ -113,7 +124,7 @@ function StudyForm({ type = "create", study = {} }) {
     }
   }, [password, checkPassword]);
 
-  //만들기 버튼 클릭 시
+  //만들기/수정하기 버튼 클릭 시
   const onHandleSubmit = async () => {
     //설명 제외 모든 곳에 입력이 되었는지 검사 -> 입력 안된 부분 있으면 토스트 메세지로 띄우기
     if (


### PR DESCRIPTION
## 개요

스터디 상세 페이지의 수정/삭제/공유 버튼의 동작을 구현했습니다.
**아직 비밀번호 세션 확인은 구현되지 않았습니다.**

## 변경 사항

- `StudyDetail.jsx`
  - 수정/삭제/공유 버튼의 동작은 모두 여기에서 정의
  - 수정 버튼 동작 작성 : 수정 버튼 클릭 → 비밀번호 모달 → 수정 페이지 → 상세 페이지  (성공 루트)
  - 삭제 버튼 동작 작성 : 삭제 버튼 클릭 → 비밀번호 모달 → 삭제 재확인 팝업 → 홈 페이지  (성공 루트)
  - 공유 버튼 동작 작성 : 공유 버튼 클릭 → 공유 모달  → 복사하기 버튼 클릭 시 URL 복사됨
    - URL은 `window.location.href` 으로 불러옴.
    - 복사 기능은 `navigator.clipboard.writeText(URL)`으로 구현.
- `SharingModal.jsx`
  - `Modal`공통 컴포넌트 사용하여 구현
- `StudyForm.jsx`
  - 스터디 상세 페이지에서, `navigate`를 사용하여 인수를 전달함에 따라, `useLocation`을 사용하여 인수를 받도록 수정함. 

## 스크린샷 (UI 변경 시)

비밀번호 모달 - 수정
<img width="465" height="422" alt="image" src="https://github.com/user-attachments/assets/bbcc688e-b9d0-4d77-b54d-9e323341d187" />

비밀번호 모달 - 삭제
<img width="475" height="440" alt="image" src="https://github.com/user-attachments/assets/59298c9b-6aa0-4318-8c3b-ebb46f5a6218" />

삭제 재확인 팝업
<img width="832" height="332" alt="image" src="https://github.com/user-attachments/assets/631657a7-cea7-432a-8efa-4fc0af3ae96b" />

공유 모달
<img width="470" height="305" alt="image" src="https://github.com/user-attachments/assets/714d0722-4cfd-4e59-a7ee-7c9165aa9c79" />


## 영향 범위

`StudyForm.jsx`수정. (#16 )

## 관련 이슈

- close #20 
