### PR TITLE
feat: 스터디 목록 UI 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -266,6 +265,31 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -273,6 +297,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -858,7 +883,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -905,7 +929,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1031,7 +1054,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1327,7 +1349,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2438,7 +2459,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2509,7 +2529,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2519,7 +2538,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2782,7 +2800,6 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2907,7 +2924,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -6,7 +6,7 @@ const COLOR_THEMES = ["GREEN", "YELLOW", "BLUE", "PINK"];
 
 const Card = ({
   nickname,
-  name,
+  title,
   points,
   days,
   description,
@@ -34,7 +34,7 @@ const Card = ({
               >
                 {nickname}
               </span>
-              의 {name}
+              의 {title}
             </h3>
             <Tag
               type="point"

--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -6,8 +6,8 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 22.375rem;
-  height: 15.1875rem;
+  height: 100%;
+  min-height: 15.1875rem;
   border-radius: 1.25rem;
   color: var(--white);
 }
@@ -15,17 +15,21 @@
 /* color theme */
 .card-GREEN {
   background-color: var(--green);
+  border: 1px solid rgb(0 0 0 / 0.1);
 }
 .card-YELLOW {
   background-color: var(--yellow);
+  border: 1px solid rgb(0 0 0 / 0.1);
 }
 
 .card-BLUE {
   background-color: var(--blue);
+  border: 1px solid rgb(0 0 0 / 0.1);
 }
 
 .card-PINK {
   background-color: var(--pink);
+  border: 1px solid rgb(0 0 0 / 0.1);
 }
 
 /* picture card */
@@ -74,11 +78,13 @@
   justify-content: space-between;
   align-items: flex-start;
   align-self: stretch;
+  gap: 0.625rem;
 }
 
 .title {
   font: var(--text-18-bold);
   margin-bottom: 0.69rem;
+  /* word-break: keep-all; */
 }
 
 .colorThemeText.title {
@@ -111,6 +117,12 @@
 }
 
 .description {
+  overflow: hidden;
+  display: -webkit-box;
+  height: 3em;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  text-overflow: ellipsis;
   font: var(--text-16-regular);
 }
 
@@ -126,15 +138,13 @@
 
 @media (max-width: 744px) {
   .card {
-    width: 19.5rem;
-    height: 15.1875rem;
+    min-height: 15.1875rem;
   }
 }
 
 @media (max-width: 375px) {
   .card {
-    width: 15rem;
-    height: 11.25rem;
+    min-height: auto;
   }
 
   .card-feed {
@@ -143,6 +153,7 @@
   }
 
   .container {
+    justify-content: flex-start;
     padding: 1rem;
   }
 
@@ -170,7 +181,9 @@
   }
 
   .description {
-    margin-bottom: 0.25rem;
+    /* margin-bottom: 0.25rem; */
+    height: 2.4em;
+    margin-block: 0.75rem;
     font: var(--text-14-regular);
     line-height: normal;
   }

--- a/src/pages/HomePage/Home.jsx
+++ b/src/pages/HomePage/Home.jsx
@@ -203,7 +203,9 @@ const Home = () => {
               );
             })
           ) : (
-            <p className={styles.notification}>아직 둘러 볼 스터디가 없어요</p>
+            <p className={styles.notification}>
+              {keyword ? "검색된" : "아직 둘러 볼"} 스터디가 없어요
+            </p>
           )}
         </div>
 

--- a/src/pages/HomePage/Home.jsx
+++ b/src/pages/HomePage/Home.jsx
@@ -1,8 +1,235 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { getStudies } from "../../api/studies";
+import useToast from "../../hooks/useToast";
+import Card from "../../components/Card/Card";
+import Toast from "../../components/Toast/Toast";
 import styles from "./Home.module.css";
 
-function Home() {
-  return <div>Home</div>;
-}
+/**
+ * 스터디 목록 UI
+ *
+ * 페이지당 6개씩 더보기 기능 구현 - 기존 데이터들은 유지되고, 불러올 6개 데이터만 추가되는 방식으로 구현
+ * 실시간 검색 기능 구현
+ * 정렬 기능 구현
+ */
+
+const RECENT_STUDIES = "recent_studies";
+const DAY = 1000 * 60 * 60 * 24; // 경과 일수 계산을 위한 하루 단위 ms 계산식
+const LIMIT = 6; // 페이지당 출력할 스터디 수 상수처리
+const SORTINGS = [
+  { label: "최근 순", sortBy: "createdAt", order: "desc" },
+  { label: "오래된 순", sortBy: "createdAt", order: "asc" },
+  { label: "많은 포인트 순", sortBy: "points", order: "desc" },
+  { label: "적은 포인트 순", sortBy: "points", order: "asc" },
+];
+// 추후에 목록 조회 API 포인트 동일할 경우 정렬 쿼리 보완
+
+const Home = () => {
+  const [initLoading, setInitLoading] = useState(true); // 초기 로딩
+  const [moreLoading, setMoreLoading] = useState(false); // 더보기 로딩
+  const [studies, setStudies] = useState([]); // 스터디 둘러보기
+  const [recentStudies, setRecentStudies] = useState([]); // 최근 조회한 스터디
+  const [page, setPage] = useState(1); // 첫 페이지 1
+  const [inputValue, setInputValue] = useState("");
+  const [keyword, setKeyword] = useState("");
+  const [sortBy, setSortBy] = useState("createdAt"); // 초기 정렬 기준 생성일시
+  const [order, setOrder] = useState("desc"); // 초기 정렬 순서 내림차순
+  const [usableMore, setUsableMore] = useState(false); // 더보기
+  const [total, setTotal] = useState(0);
+  const [shownSortingList, setShownSortingList] = useState("");
+  const { toast, showToast } = useToast();
+
+  useEffect(() => {
+    setPage(1);
+    setStudies([]);
+  }, [keyword, sortBy, order]);
+
+  useEffect(() => {
+    const fetchStudies = async () => {
+      try {
+        page === 1 ? setInitLoading(true) : setMoreLoading(true);
+
+        const params = { page, limit: LIMIT, sortBy, order };
+        if (keyword) params.keyword = keyword;
+
+        // console.log(params);
+
+        const res = await getStudies(params);
+        const { data, total, has_more } = res.data;
+
+        setStudies((prev) => [...prev, ...data]);
+        setUsableMore(has_more);
+        setTotal(total);
+      } catch (error) {
+        console.error(`데이터 조회 실패: ${error}`);
+      } finally {
+        setInitLoading(false);
+        setMoreLoading(false);
+      }
+    };
+
+    fetchStudies();
+  }, [page, keyword, sortBy, order]);
+
+  useEffect(() => {
+    const studies = localStorage.getItem(RECENT_STUDIES) || [];
+
+    console.log(studies);
+
+    setRecentStudies(studies);
+  }, []);
+
+  const currentSort = SORTINGS.find(
+    (obj) => obj.sortBy === sortBy && obj.order === order,
+  )?.label;
+
+  const handleSort = (obj) => {
+    setSortBy(obj.sortBy);
+    setOrder(obj.order);
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    setKeyword(inputValue);
+  };
+
+  return (
+    <div className={styles.boxWrap}>
+      <div className={styles.box}>
+        <h2 className={styles.headline}>최근 조회한 스터디</h2>
+
+        <div className={`${styles.cardList} ${styles.recent}`}>
+          {recentStudies.length ? (
+            recentStudies.map((study) => {
+              const createdAt = new Date(study.createdAt);
+              const today = new Date();
+              const diffDays = Math.ceil(
+                (today.getTime() - createdAt.getTime()) / DAY,
+              );
+
+              return (
+                <Link key={study.id} to={`/studies/${study.id}`}>
+                  <Card
+                    nickname={study.nickname}
+                    title={study.title}
+                    description={study.description}
+                    days={diffDays}
+                    points={study.points}
+                    theme={study.theme}
+                    emojis={study.emojis}
+                  />
+                </Link>
+              );
+            })
+          ) : (
+            <p className={styles.notification}>아직 조회한 스터디가 없어요</p>
+          )}
+        </div>
+      </div>
+
+      <div className={styles.box}>
+        <h2 className={styles.headline}>스터디 둘러보기</h2>
+
+        <div className={styles.controlBox}>
+          <div className={styles.searchBox}>
+            <form onSubmit={handleSubmit} autoComplete="off">
+              <input
+                type="text"
+                name="keyword"
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                className={styles.formInput}
+                placeholder="검색"
+              />
+              <button type="submit" className={styles.btnSearch}>
+                <span className={styles.srOnly}>검색</span>
+              </button>
+            </form>
+          </div>
+
+          <div className={`${styles.sortingBox} ${styles[shownSortingList]}`}>
+            <button
+              className={styles.currentSort}
+              onClick={() =>
+                setShownSortingList((prev) => (prev === "" ? "show" : ""))
+              }
+            >
+              {currentSort}
+            </button>
+
+            <ul className={styles.sortingList}>
+              {SORTINGS.map((obj) => (
+                <li key={obj.label}>
+                  <button
+                    onClick={() => {
+                      handleSort(obj);
+                      setShownSortingList("");
+                    }}
+                  >
+                    {obj.label}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <div className={styles.cardList}>
+          {initLoading ? (
+            <p className={styles.notification}>불러오는 중...</p>
+          ) : studies.length ? (
+            studies.map((study) => {
+              // console.log(study);
+              const createdAt = new Date(study.createdAt);
+              const today = new Date();
+              const diffDays = Math.ceil(
+                (today.getTime() - createdAt.getTime()) / DAY,
+              );
+
+              return (
+                <Link key={study.id} to={`/studies/${study.id}`}>
+                  <Card
+                    nickname={study.nickname}
+                    title={study.title}
+                    description={study.description}
+                    days={diffDays}
+                    points={study.points}
+                    theme={study.theme}
+                    emojis={study.emojis}
+                  />
+                </Link>
+              );
+            })
+          ) : (
+            <p className={styles.notification}>아직 둘러 볼 스터디가 없어요</p>
+          )}
+        </div>
+
+        <div className={styles.btnWrap}>
+          {moreLoading ? (
+            <p className={styles.notification}>불러오는 중...</p>
+          ) : (
+            <button
+              onClick={() =>
+                usableMore
+                  ? setPage((prev) => prev + 1)
+                  : showToast("warning", "더 불러올 스터디가 없어요")
+              }
+              className={styles.btnMore}
+            >
+              더보기
+            </button>
+          )}
+        </div>
+
+        <div className={styles.toast}>
+          {toast && <Toast type={toast.type} text={toast.text} />}
+        </div>
+      </div>
+    </div>
+  );
+};
 
 export default Home;

--- a/src/pages/HomePage/Home.module.css
+++ b/src/pages/HomePage/Home.module.css
@@ -1,0 +1,223 @@
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+.boxWrap {
+  width: 100%;
+}
+
+.box {
+  width: min(100%, 75rem);
+  padding: 2.5rem;
+  margin-inline: auto;
+  background-color: var(--white);
+  border-radius: 1.25rem;
+}
+
+.box:not(:first-child) {
+  margin-top: 2.5rem;
+}
+
+.box .headline {
+  font: var(--text-24-bold);
+  color: var(--black);
+}
+
+.controlBox {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  margin-block: 1.5rem;
+}
+
+.searchBox {
+  position: relative;
+  flex: 1;
+}
+
+.formInput {
+  display: block;
+  width: min(100%, 20.9375rem);
+  height: 2.625rem;
+  padding-inline: 3rem 1.25rem;
+  background-color: var(--white);
+  border: 1px solid var(--gray-300);
+  border-radius: 0.9375rem;
+}
+
+.btnSearch {
+  position: absolute;
+  top: 50%;
+  left: 1.25rem;
+  width: 1.125rem;
+  background-color: transparent;
+  border: 0;
+  background-image: url("../../assets/images/icon/search.png");
+  background-image: url("../../assets/images/icon/search.svg");
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+  aspect-ratio: 1;
+  translate: 0 -50%;
+}
+
+.sortingBox {
+  position: relative;
+}
+
+.currentSort {
+  display: flex;
+  position: relative;
+  width: 180px;
+  padding-block: 0.75rem;
+  padding-inline: 1.25rem 2.75rem;
+  background-color: var(--white);
+  border: 1px solid var(--gray-300);
+  border-radius: 0.9375rem;
+  font: var(--text-16-normal);
+  color: var(--gray-500);
+  cursor: pointer;
+}
+
+.currentSort::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 1.6875rem;
+  border-style: solid;
+  border-width: 4px 4px 0 4px;
+  border-color: var(--gray-500) transparent transparent transparent;
+  translate: 0 -50%;
+}
+
+.sortingList {
+  overflow: hidden;
+  position: absolute;
+  top: 100%;
+  width: 100%;
+  background-color: var(--white);
+  border: 1px solid var(--gray-300);
+  border-radius: 0.9375rem;
+  opacity: 0;
+  visibility: hidden;
+  transition: all 0.3s;
+  z-index: 1;
+}
+
+.sortingList li:not(:first-child) {
+  border-top: 1px solid var(--gray-300);
+}
+
+.sortingList button {
+  display: block;
+  width: 100%;
+  padding-block: 0.75rem;
+  font: var(--text-16-normal);
+  color: var(--black);
+  text-align: center;
+}
+
+.sortingBox.show .sortingList {
+  top: calc(100% + 0.5rem);
+  opacity: 1;
+  visibility: visible;
+}
+
+.sortingBox.show .currentSort::after {
+  border-width: 0px 4px 4px 4px;
+  border-color: transparent transparent var(--gray-500) transparent;
+}
+
+.cardList {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+}
+
+.notification {
+  grid-column: 1 / span 3;
+  padding-block: 1.25rem;
+  font: var(--text-20-medium);
+  color: var(--gray-500);
+  text-align: center;
+}
+
+.recent .notification {
+  padding-block: 6.25rem 8.75rem;
+}
+
+.btnWrap {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  margin-top: 3.75rem;
+}
+
+.btnMore {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: min(100%, 17.5rem);
+  padding-block: 1.0625rem;
+  background-color: var(--white);
+  border: 1px solid var(--gray-300);
+  border-radius: 1.25rem;
+  font: var(--text-16-medium);
+  color: var(--green-text);
+  cursor: pointer;
+}
+
+@media all and (max-width: 744px) {
+  .box {
+    padding: 1.5rem;
+  }
+
+  .cardList {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media all and (max-width: 375px) {
+  .box {
+    padding: 1rem;
+  }
+
+  .box .headline {
+    margin-bottom: 1rem;
+    font: var(--text-16-bold);
+  }
+
+  .controlBox {
+    flex-direction: column;
+    align-items: flex-end;
+    margin-block: 1rem 0.75rem;
+  }
+
+  .searchBox {
+    width: 100%;
+  }
+
+  .cardList {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .btnWrap {
+    margin-top: 1.875rem;
+  }
+
+  .btnMore {
+    width: min(100%, 17.5rem);
+  }
+}


### PR DESCRIPTION
## 개요

스터디 목록 UI (Home) 작업 및 API 데이터 연동
초기 로딩시 로딩 문구 출력 후 데이터를 가져오면 데이터를 출력
최근 조회한 스터디의 경우 상세에 접속하면 localStorage 에 저장되게 구현할 예정
스터디 목록 UI (Home) 에서는 저장된 localStorage 만 불러와서 출력

## 변경 사항

1. 검색 기능 구현
    - 검색어 입력 후 엔터로 검색
    - 검색된 결과가 없을 경우 "검색된 스터디가 없어요" notification 문구 출력
2. 정렬 기능 구현
    - 현재 정렬 기준 표시
    - 버튼 클릭시 정렬 기준 LIst UI 토글 인터랙션 css 로 구현 fadeInDown <> fadeOutUp
3. 더보기 기능 구현 
    - 더보기 클릭시 기존 목록 유지한 채 불러와야 할 6개만 불러오기
    - 더보기 클릭시 데이터를 불러오는 동안 버튼이 사라지고 "불러오는 중..." notification 으로 대체 출력, 데이터가 불러와지면 다시 버튼으로 교체 출력
    - 더이상 불러올 스터디 목록이 없을 경우 useToast 를 이용해 Toast 출력
    
## 스크린샷 (UI 변경 시)

<img width="1728" height="963" alt="image" src="https://github.com/user-attachments/assets/7d9c745e-c4f2-43ef-99f3-bd2e9759c321" />
👉 첫 데이터를 불러오는 화면

---

<img width="1728" height="963" alt="image" src="https://github.com/user-attachments/assets/cf381ccd-706d-4780-b301-994be038e54b" />
👉 첫 데이터를 불러온 화면

---

<img width="1728" height="963" alt="image" src="https://github.com/user-attachments/assets/7da86a85-4697-4804-ad08-7389f1b16b43" />
👉 더보기 클릭시 기존 목록은 유지된 채 다음 목록만 불러오게 구현

---

<img width="1728" height="963" alt="image" src="https://github.com/user-attachments/assets/ef2b4f53-021b-407b-86f5-433d36535646" />
👉 더이상 불러올 목록이 없을 때 뜨는 Toast UI

---

<img width="1728" height="963" alt="image" src="https://github.com/user-attachments/assets/114fed71-a1fc-43fc-b8c2-844f687f25ba" />
👉 검색어로 검색된 스터디가 없을 경우

---

등등... 

## 영향 범위

작업 중 Card 컴포넌트를 수정 - props 명 수정 및 css 스타일 수정

## 관련 이슈

- close #15 
