### PR TITLE
feat: 집중 타이머 시간 설정 기능 추가

### DIFF
--- a/src/hooks/useTimer.js
+++ b/src/hooks/useTimer.js
@@ -17,6 +17,7 @@ function useTimer(studyId, durationSec) {
   const [timerStatus, setTimerStatus] = useState(TIMER_STATUS.IDLE);
   const [timeLeft, setTimeLeft] = useState(durationSec);
   const [earnedPoint, setEarnedPoint] = useState(0);
+  const [sessionDuration, setSessionDuration] = useState(null); // 페이지 재진입 시 타이머 설정 시간 표시
 
   const endTimeRef = useRef(null); // Date.now와 종료 시각을 기준으로 남은 시간 계산
   const intervalIdRef = useRef(null); // 현재 실행 중인 Interval의 ID
@@ -69,6 +70,7 @@ function useTimer(studyId, durationSec) {
           endTimeRef.current = new Date(data.endTime);
           setTimeLeft(remaining);
           setTimerStatus(TIMER_STATUS.RUNNING);
+          setSessionDuration(data.durationMin * 60);
         } else if (data.status === TIMER_STATUS.PAUSED) {
           // paused: endTime - pausedAt 으로 남은 시간 계산
           const remaining = Math.ceil(
@@ -84,6 +86,7 @@ function useTimer(studyId, durationSec) {
           endTimeRef.current = new Date(Date.now() + remaining * 1000);
           setTimeLeft(remaining > 0 ? remaining : 0);
           setTimerStatus(TIMER_STATUS.RUNNING);
+          setSessionDuration(data.durationMin * 60);
         }
       } catch (e) {
         showToast("warning", e.userMessage);
@@ -179,6 +182,7 @@ function useTimer(studyId, durationSec) {
     pause,
     resume,
     toast,
+    sessionDuration,
   };
 }
 

--- a/src/hooks/useTimer.js
+++ b/src/hooks/useTimer.js
@@ -13,10 +13,8 @@ export const TIMER_STATUS = {
   COMPLETED: "completed", // 종료
 };
 
-const DURATION_MIN = 25; // 타이머 시간 초기값
-
-function useTimer(studyId) {
-  const initialSeconds = DURATION_MIN * 60;
+function useTimer(studyId, durationMin) {
+  const initialSeconds = durationMin * 60;
 
   const [timerStatus, setTimerStatus] = useState(TIMER_STATUS.IDLE);
   const [timeLeft, setTimeLeft] = useState(initialSeconds);
@@ -129,7 +127,7 @@ function useTimer(studyId) {
   const start = async () => {
     try {
       const res = await createFocusSession(studyId, {
-        durationMin: DURATION_MIN,
+        durationMin: durationMin,
       });
 
       const { data } = res.data;
@@ -180,7 +178,6 @@ function useTimer(studyId) {
   return {
     timerStatus,
     timeLeft,
-    initialSeconds,
     earnedPoint,
     start,
     pause,

--- a/src/hooks/useTimer.js
+++ b/src/hooks/useTimer.js
@@ -13,11 +13,9 @@ export const TIMER_STATUS = {
   COMPLETED: "completed", // 종료
 };
 
-function useTimer(studyId, durationMin) {
-  const initialSeconds = durationMin * 60;
-
+function useTimer(studyId, durationSec) {
   const [timerStatus, setTimerStatus] = useState(TIMER_STATUS.IDLE);
-  const [timeLeft, setTimeLeft] = useState(initialSeconds);
+  const [timeLeft, setTimeLeft] = useState(durationSec);
   const [earnedPoint, setEarnedPoint] = useState(0);
 
   const endTimeRef = useRef(null); // Date.now와 종료 시각을 기준으로 남은 시간 계산
@@ -127,14 +125,14 @@ function useTimer(studyId, durationMin) {
   const start = async () => {
     try {
       const res = await createFocusSession(studyId, {
-        durationMin: durationMin,
+        durationMin: Math.ceil(durationSec / 60),
       });
 
       const { data } = res.data;
 
       sessionIdRef.current = data.id;
-      endTimeRef.current = new Date(data.endTime);
-      setTimeLeft(initialSeconds);
+      endTimeRef.current = new Date(Date.now() + durationSec * 1000);
+      setTimeLeft(durationSec);
       setTimerStatus(data.status);
     } catch (e) {
       showToast("warning", e.userMessage);
@@ -150,6 +148,7 @@ function useTimer(studyId, durationMin) {
 
       const { data } = res.data;
 
+      endTimeRef.current = null;
       setTimerStatus(data.status);
       showToast("warning", "집중이 중단되었습니다.");
     } catch (e) {
@@ -159,16 +158,13 @@ function useTimer(studyId, durationMin) {
 
   const resume = async () => {
     try {
-      const requestedAt = Date.now();
-
       const res = await updateFocusSession(studyId, sessionIdRef.current, {
         action: TIMER_STATUS.RUNNING,
       });
 
       const { data } = res.data;
 
-      const elapsed = Date.now() - requestedAt;
-      endTimeRef.current = new Date(new Date(data.endTime).getTime() - elapsed);
+      endTimeRef.current = new Date(Date.now() + timeLeft * 1000);
       setTimerStatus(data.status);
     } catch (e) {
       showToast("warning", e.userMessage);

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -56,9 +56,12 @@ function Focus() {
 
   // input 값대로 타이머 시간 설정
   const handleInputChange = (min, sec) => {
-    const m = Math.min(99, Math.max(0, parseInt(min) || 0));
+    const m = Math.min(99, Math.max(0, parseInt(min) || 1));
     const s = Math.min(59, Math.max(0, parseInt(sec) || 0));
-    setDurationSec(m * 60 + s);
+
+    setInputMin(String(m));
+    setInputSec(String(s).padStart(2, "0"));
+    setDurationSec(Math.max(1, m * 60 + s));
   };
 
   return (
@@ -135,10 +138,8 @@ function Focus() {
                 min="1"
                 max="99"
                 value={inputMin}
-                onChange={(e) => {
-                  setInputMin(e.target.value);
-                  handleInputChange(e.target.value, inputSec);
-                }}
+                onChange={(e) => setInputMin(e.target.value)}
+                onBlur={() => handleInputChange(inputMin, inputSec)}
               />
               <span className={styles.timeSep}>:</span>
               <input
@@ -147,10 +148,8 @@ function Focus() {
                 min="0"
                 max="59"
                 value={inputSec}
-                onChange={(e) => {
-                  setInputSec(e.target.value);
-                  handleInputChange(inputMin, e.target.value);
-                }}
+                onChange={(e) => setInputSec(e.target.value)}
+                onBlur={() => handleInputChange(inputMin, inputSec)}
               />
             </div>
           ) : (

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -8,6 +8,7 @@ import useTimer, { TIMER_STATUS } from "../../hooks/useTimer";
 import formatTime from "./formatTime";
 import styles from "./Focus.module.css";
 
+// 타이머 프리셋 버튼: 버튼 클릭 시 바로 적용되는 시간(분)
 const PRESETS = [15, 25, 50];
 
 function Focus() {
@@ -20,8 +21,9 @@ function Focus() {
   const [inputMin, setInputMin] = useState("25");
   const [inputSec, setInputSec] = useState("00");
 
-  const minInputRef = useRef(null);
+  const minInputRef = useRef(null); // 직접입력 버튼 클릭 시 분 input에 자동으로 포커스줄 용도
 
+  // 스터디 정보 조회 (추후 전역 상태로 수정 예정)
   useEffect(() => {
     const fetchStudy = async () => {
       const res = await getStudyDetail(studyId);
@@ -32,9 +34,23 @@ function Focus() {
     fetchStudy();
   }, [studyId]);
 
-  const { timerStatus, timeLeft, earnedPoint, start, pause, resume, toast } =
-    useTimer(studyId, durationSec);
+  const {
+    timerStatus,
+    timeLeft,
+    earnedPoint,
+    start,
+    pause,
+    resume,
+    toast,
+    sessionDuration,
+  } = useTimer(studyId, durationSec);
 
+  // 페이지 재진입 시 타이머 설정 시간 표시
+  useEffect(() => {
+    if (sessionDuration) setDurationSec(sessionDuration);
+  }, [sessionDuration]);
+
+  // 타이머 상태: 진행/중지/완료/시작 전
   const isRunning = timerStatus === TIMER_STATUS.RUNNING;
   const isPaused = timerStatus === TIMER_STATUS.PAUSED;
   const isCompleted = timerStatus === TIMER_STATUS.COMPLETED;
@@ -70,6 +86,7 @@ function Focus() {
         <Toast type={toast.type} text={toast.text} point={toast.point} />
       )}
 
+      {/* 스터디 정보 표시 */}
       <div className={styles.header}>
         <div className={styles.headerTop}>
           <h2 className={styles.title}>
@@ -89,12 +106,15 @@ function Focus() {
         </div>
       </div>
 
+      {/* 타이머 */}
       <div className={styles.timerSection}>
         <div className={styles.timerSectionheader}>
           <h3 className={styles.timerTitle}>오늘의 집중</h3>
 
+          {/* 타이머 시작 전/완료: 집중 시간 설정 UI 표시 */}
           {isIdle || isCompleted ? (
             <div className={styles.timerPresets}>
+              {/* 프리셋 버튼: 버튼 클릭 시 15분/25분/50분 시간 설정 */}
               {PRESETS.map((min) => (
                 <button
                   key={min}
@@ -108,6 +128,7 @@ function Focus() {
                   {min}분
                 </button>
               ))}
+              {/* 직접 입력 버튼: 버튼 클릭 시 분/초 직접 설정 */}
               <button
                 type="button"
                 className={`${styles.presetBtn} ${isEditing ? styles.active : ""}`}
@@ -118,6 +139,7 @@ function Focus() {
             </div>
           ) : (
             <div className={styles.timerSetTime}>
+              {/* 타이머 진행 중/일시중지: 타이머 설정 시간 표시 */}
               <span className={`ic timer ${styles.timerSetIcon}`}></span>
               <span className={styles.timerSetValue}>
                 {formatTime(durationSec)}
@@ -129,6 +151,8 @@ function Focus() {
         <div
           className={`${styles.timerDisplay} ${isRunning || isPaused ? styles.timerActive : ""}`}
         >
+          {/* 직접 입력 버튼을 클릭한 경우 타이머 시간(분/초) 입력 Input */}
+          {/* 그 외의 경우에는 사용자가 설정한 타이머 시간 */}
           {isEditing ? (
             <div className={styles.timerEdit}>
               <input
@@ -157,7 +181,9 @@ function Focus() {
           )}
         </div>
 
+        {/* 타이머 조작 버튼 (시작/일시정지/재시작) */}
         <div className={styles.btnContainer}>
+          {/* 타이머 시작 전/완료: 시작 버튼만 표시 */}
           {isIdle || isCompleted ? (
             <button
               type="button"
@@ -172,6 +198,7 @@ function Focus() {
             </button>
           ) : (
             <>
+              {/* 타이머 진행 중/일시중지: 시작, 일시정지, 재시작 버튼 모두 표시 */}
               <button
                 type="button"
                 className={`${styles.btnBase} ${styles.btnCircle} ${styles.timerPauseButton}`}

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { getStudyDetail } from "../../api/studies";
 import BoxHeaderInfo from "../../components/BoxHeader/BoxHeaderInfo";
@@ -13,9 +13,14 @@ const PRESETS = [15, 25, 50];
 function Focus() {
   const navigate = useNavigate();
   const { studyId } = useParams();
-  const [study, setStudy] = useState(null);
 
-  const [durationMin, setDurationMin] = useState(25);
+  const [study, setStudy] = useState(null);
+  const [durationSec, setDurationSec] = useState(25 * 60);
+  const [isEditing, setIsEditing] = useState(false);
+  const [inputMin, setInputMin] = useState("25");
+  const [inputSec, setInputSec] = useState("00");
+
+  const minInputRef = useRef(null);
 
   useEffect(() => {
     const fetchStudy = async () => {
@@ -28,12 +33,33 @@ function Focus() {
   }, [studyId]);
 
   const { timerStatus, timeLeft, earnedPoint, start, pause, resume, toast } =
-    useTimer(studyId, durationMin);
+    useTimer(studyId, durationSec);
 
   const isRunning = timerStatus === TIMER_STATUS.RUNNING;
   const isPaused = timerStatus === TIMER_STATUS.PAUSED;
   const isCompleted = timerStatus === TIMER_STATUS.COMPLETED;
   const isIdle = timerStatus === TIMER_STATUS.IDLE;
+
+  // 프리셋 버튼 클릭
+  const handleSelectPreset = (min) => {
+    setDurationSec(min * 60);
+    setIsEditing(false);
+  };
+
+  // 직접 입력 버튼 클릭
+  const handleSelectCustom = () => {
+    setInputMin(String(Math.floor(durationSec / 60)));
+    setInputSec(String(durationSec % 60).padStart(2, "0"));
+    setIsEditing(true);
+    setTimeout(() => minInputRef.current?.focus(), 0);
+  };
+
+  // input 값대로 타이머 시간 설정
+  const handleInputChange = (min, sec) => {
+    const m = Math.min(99, Math.max(0, parseInt(min) || 0));
+    const s = Math.min(59, Math.max(0, parseInt(sec) || 0));
+    setDurationSec(m * 60 + s);
+  };
 
   return (
     <section className={styles.container}>
@@ -70,35 +96,77 @@ function Focus() {
                 <button
                   key={min}
                   type="button"
-                  className={`${styles.presetBtn} ${durationMin === min ? styles.active : ""}`}
-                  onClick={() => setDurationMin(min)}
+                  className={`
+                    ${styles.presetBtn} 
+                    ${!isEditing && durationSec === min * 60 ? styles.active : ""}
+                  `}
+                  onClick={() => handleSelectPreset(min)}
                 >
                   {min}분
                 </button>
               ))}
+              <button
+                type="button"
+                className={`${styles.presetBtn} ${isEditing ? styles.active : ""}`}
+                onClick={handleSelectCustom}
+              >
+                직접 입력
+              </button>
             </div>
           ) : (
             <div className={styles.timerSetTime}>
               <span className={`ic timer ${styles.timerSetIcon}`}></span>
               <span className={styles.timerSetValue}>
-                {formatTime(durationMin)}
+                {formatTime(durationSec)}
               </span>
             </div>
           )}
         </div>
 
-        <p
+        <div
           className={`${styles.timerDisplay} ${isRunning || isPaused ? styles.timerActive : ""}`}
         >
-          {formatTime(isIdle || isCompleted ? durationMin * 60 : timeLeft)}
-        </p>
+          {isEditing ? (
+            <div className={styles.timerEdit}>
+              <input
+                ref={minInputRef}
+                className={styles.timeInput}
+                type="number"
+                min="1"
+                max="99"
+                value={inputMin}
+                onChange={(e) => {
+                  setInputMin(e.target.value);
+                  handleInputChange(e.target.value, inputSec);
+                }}
+              />
+              <span className={styles.timeSep}>:</span>
+              <input
+                className={styles.timeInput}
+                type="number"
+                min="0"
+                max="59"
+                value={inputSec}
+                onChange={(e) => {
+                  setInputSec(e.target.value);
+                  handleInputChange(inputMin, e.target.value);
+                }}
+              />
+            </div>
+          ) : (
+            formatTime(isIdle || isCompleted ? durationSec : timeLeft)
+          )}
+        </div>
 
         <div className={styles.btnContainer}>
           {isIdle || isCompleted ? (
             <button
               type="button"
               className={`${styles.btnBase} ${styles.timerStartButton}`}
-              onClick={start}
+              onClick={() => {
+                if (isEditing) setIsEditing(false);
+                start();
+              }}
             >
               <span className="ic play"></span>
               Start!

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -8,6 +8,8 @@ import useTimer, { TIMER_STATUS } from "../../hooks/useTimer";
 import formatTime from "./formatTime";
 import styles from "./Focus.module.css";
 
+const PRESETS = [15, 25, 50];
+
 function Focus() {
   const navigate = useNavigate();
   const { studyId } = useParams();
@@ -17,14 +19,9 @@ function Focus() {
 
   useEffect(() => {
     const fetchStudy = async () => {
-      try {
-        const res = await getStudyDetail(studyId);
-        const { data } = res.data;
-        console.log(data);
-        setStudy(data);
-      } catch (e) {
-        console.error(e);
-      }
+      const res = await getStudyDetail(studyId);
+      const { data } = res.data;
+      setStudy(data);
     };
 
     fetchStudy();
@@ -67,7 +64,20 @@ function Focus() {
         <div className={styles.timerSectionheader}>
           <h3 className={styles.timerTitle}>오늘의 집중</h3>
 
-          {(isRunning || isPaused) && (
+          {isIdle || isCompleted ? (
+            <div className={styles.timerPresets}>
+              {PRESETS.map((min) => (
+                <button
+                  key={min}
+                  type="button"
+                  className={`${styles.presetBtn} ${durationMin === min ? styles.active : ""}`}
+                  onClick={() => setDurationMin(min)}
+                >
+                  {min}분
+                </button>
+              ))}
+            </div>
+          ) : (
             <div className={styles.timerSetTime}>
               <span className={`ic timer ${styles.timerSetIcon}`}></span>
               <span className={styles.timerSetValue}>
@@ -80,7 +90,7 @@ function Focus() {
         <p
           className={`${styles.timerDisplay} ${isRunning || isPaused ? styles.timerActive : ""}`}
         >
-          {formatTime(isCompleted ? durationMin : timeLeft)}
+          {formatTime(isIdle || isCompleted ? durationMin * 60 : timeLeft)}
         </p>
 
         <div className={styles.btnContainer}>

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -13,6 +13,8 @@ function Focus() {
   const { studyId } = useParams();
   const [study, setStudy] = useState(null);
 
+  const [durationMin, setDurationMin] = useState(25);
+
   useEffect(() => {
     const fetchStudy = async () => {
       try {
@@ -28,16 +30,8 @@ function Focus() {
     fetchStudy();
   }, [studyId]);
 
-  const {
-    timerStatus,
-    timeLeft,
-    initialSeconds,
-    earnedPoint,
-    start,
-    pause,
-    resume,
-    toast,
-  } = useTimer(studyId);
+  const { timerStatus, timeLeft, earnedPoint, start, pause, resume, toast } =
+    useTimer(studyId, durationMin);
 
   const isRunning = timerStatus === TIMER_STATUS.RUNNING;
   const isPaused = timerStatus === TIMER_STATUS.PAUSED;
@@ -77,7 +71,7 @@ function Focus() {
             <div className={styles.timerPresetTime}>
               <span className={`ic timer ${styles.timerPresetIcon}`}></span>
               <span className={styles.timerPresetValue}>
-                {formatTime(initialSeconds)}
+                {formatTime(durationMin)}
               </span>
             </div>
           )}
@@ -86,7 +80,7 @@ function Focus() {
         <p
           className={`${styles.timerDisplay} ${isRunning || isPaused ? styles.timerActive : ""}`}
         >
-          {formatTime(isCompleted ? initialSeconds : timeLeft)}
+          {formatTime(isCompleted ? durationMin : timeLeft)}
         </p>
 
         <div className={styles.btnContainer}>

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -68,9 +68,9 @@ function Focus() {
           <h3 className={styles.timerTitle}>오늘의 집중</h3>
 
           {(isRunning || isPaused) && (
-            <div className={styles.timerPresetTime}>
-              <span className={`ic timer ${styles.timerPresetIcon}`}></span>
-              <span className={styles.timerPresetValue}>
+            <div className={styles.timerSetTime}>
+              <span className={`ic timer ${styles.timerSetIcon}`}></span>
+              <span className={styles.timerSetValue}>
                 {formatTime(durationMin)}
               </span>
             </div>

--- a/src/pages/FocusPage/Focus.module.css
+++ b/src/pages/FocusPage/Focus.module.css
@@ -70,6 +70,41 @@
   color: var(--black);
 }
 
+.timerPresets {
+  display: flex;
+  gap: 0.8rem;
+  margin-top: 1.5rem;
+}
+
+.presetBtn {
+  padding: 0.375rem 0.8rem;
+  border-radius: 0.7rem;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  font: var(--text-16-medium);
+  color: var(--black);
+  background: rgba(255, 255, 255, 0.3);
+  transition: all 0.15s ease;
+}
+
+.presetBtn:hover {
+  background-color: var(--green);
+}
+
+.presetBtn:active {
+  transform: scale(0.97);
+}
+
+.presetBtn:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+
+.presetBtn.active {
+  background-color: var(--brand);
+  color: var(--white);
+  border-color: var(--brand);
+}
+
 .timerSetTime {
   display: flex;
   align-items: center;

--- a/src/pages/FocusPage/Focus.module.css
+++ b/src/pages/FocusPage/Focus.module.css
@@ -70,7 +70,7 @@
   color: var(--black);
 }
 
-.timerPresetTime {
+.timerSetTime {
   display: flex;
   align-items: center;
   gap: 0.25rem;
@@ -85,11 +85,11 @@
   background: rgba(255, 255, 255, 0.3);
 }
 
-.timerPresetIcon {
+.timerSetIcon {
   font-size: 1.1875rem;
 }
 
-.timerPresetValue {
+.timerSetValue {
   font: var(--text-16-medium);
   line-height: 1.1875rem;
   color: var(--black);
@@ -205,7 +205,7 @@
     padding: 1.5rem 1rem;
   }
 
-  .timerPresetTime {
+  .timerSetTime {
     margin-top: 1rem;
   }
 

--- a/src/pages/FocusPage/Focus.module.css
+++ b/src/pages/FocusPage/Focus.module.css
@@ -140,6 +140,25 @@
   color: var(--red);
 }
 
+/* 입력 모드 */
+.timeInput {
+  width: 2ch;
+  height: 100%;
+  font: inherit;
+  appearance: none;
+}
+
+.timeInput::-webkit-outer-spin-button,
+.timeInput::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+}
+
+.timeInput:focus,
+.timeInput:focus-visible {
+  outline: none;
+  border-bottom: 2px solid var(--brand);
+}
+
 /* 타이머 조작 버튼 */
 .btnContainer {
   display: flex;


### PR DESCRIPTION
## 개요
기존에 25분으로 고정되어 있던 타이머 시간을 사용자가 직접 설정할 수 있도록 기능을 추가했습니다. 
프리셋 버튼(15분/25분/50분) 클릭 또는 직접 입력(분/초)으로 시간을 설정할 수 있으며, 설정한 시간이 API로 전달되어 서버와 연동됩니다.

## 변경 사항
- 타이머 설정 시간을 `DURATION_MIN` 상수에서 `durationSec` 상태값으로 변경
- 프리셋 버튼 UI 추가 (15분 / 25분 / 50분)
- 직접 입력 버튼 클릭 시 타이머 시간이 분/초 input으로 전환되는 인라인 편집 UI 추가
- 직접 입력 시 유효성 검증 추가 (분 1에서 99, 초 0에서 59)
   - 자연스러운 사용자 경험을 위해 입력 중에는 값을 제한하지 않고,  blur 시 범위를 벗어난 값 자동 보정
- 변경된 시간을 세션 생성 API에 전달
- 페이지 재진입 시 진행 중/일시정지 세션의 설정 시간 표시

## 스크린샷 (UI 변경 시)

### 페이지 진입 시 기본값 25분 설정
<img width="1469" height="992" alt="localhost_5173_studies_17_focus" src="https://github.com/user-attachments/assets/1793649a-d2c0-417d-a7dc-b56444110596" />

### 프리셋 버튼 클릭으로 시간 설정
<img width="1469" height="992" alt="localhost_5173_studies_17_focus (1)" src="https://github.com/user-attachments/assets/8c975cc9-df25-40d5-882f-2094f6d2bdca" />

### 직접 입력 버튼 클릭으로 분/초 설정 가능
<img width="1461" height="990" alt="스크린샷 2026-04-18 오후 7 54 40" src="https://github.com/user-attachments/assets/7a075648-5244-437a-a2f7-fb9dd574c5bf" />

- 버튼 클릭 시 자동으로 분 input에 포커스 가도록 설정

### 시간 설정 후 시작 버튼 클릭 시 타이머 작동
<img width="1469" height="992" alt="localhost_5173_studies_17_focus (3)" src="https://github.com/user-attachments/assets/d91a182a-da9e-4015-8bfd-be200060c0ea" />

- 타이머 시작/일시 정지/종료 모두 가능

## 미구현 사항
- **초 단위 시간 설정 시 페이지 재진입 후 타이머 복원 오류**
  - 원인: 집중 시간을 분 단위 정수(`durationMin`)로 저장하고 있어, 초 단위로 설정한 시간(예: 1:30)을 반올림 처리(2분)헤 서버에 전달하고 있음 → 이로 인해 페이지 재진입 시 서버의 `endTime` 기준으로 남은 시간을 복원하면 사용자가 설정한 시간과 불일치가 발생함
  - 해결 예정
  - 해당 이슈는 팀 노션의 트러블 슈팅에 정리해놓았으니 참고 부탁드립니다! (https://www.notion.so/3467c51d9128808fbaf8c55bfb15b1f6)


- **동적 포인트 지급 로직 미구현**
  - 현재 세션 완료 시 설정 시간과 상관 없이 무조건 8포인트 고정 지급
  - 구현 예정

- **페이지 재진입 시 타이머 자동 재시작**
  - 현재 진행 중/일시정지 상태에서 페이지를 나갔다가 돌아오면 자동으로 재시작됨
  - 추후 사용자가 재시작 여부를 직접 결정할 수 있도록 구현 예정


## 관련 이슈
- close #22
