### PR TITLE
refactor: 타이머 완료 중복 호출 방어 처리

### DIFF
--- a/src/hooks/useTimer.js
+++ b/src/hooks/useTimer.js
@@ -22,11 +22,15 @@ function useTimer(studyId, durationSec) {
   const endTimeRef = useRef(null); // Date.now와 종료 시각을 기준으로 남은 시간 계산
   const intervalIdRef = useRef(null); // 현재 실행 중인 Interval의 ID
   const sessionIdRef = useRef(null);
+  const isCompletingRef = useRef(false); // 타이머 완료 API 중복 호출 방어 플래그
 
   const { toast, showToast } = useToast();
 
   // 타이머 완료 처리
   const handleComplete = useCallback(async () => {
+    if (isCompletingRef.current) return;
+    isCompletingRef.current = true;
+
     try {
       const res = await updateFocusSession(studyId, sessionIdRef.current, {
         action: TIMER_STATUS.COMPLETED,
@@ -39,6 +43,7 @@ function useTimer(studyId, durationSec) {
       setTimerStatus(data.status);
       showToast("success", "포인트를 획득했습니다!", pointResult);
     } catch (e) {
+      isCompletingRef.current = false;
       showToast("warning", e.userMessage);
     }
   }, [showToast, studyId]);


### PR DESCRIPTION
## 개요

현재는 `useTimer.js` 내부의 `fetchSession`과 타이머 interval 두 곳에서 모두 `remaining <= 0`일 때 `handleComplete`를 중복 호출할 수 있는 구조입니다.
- 예: 페이지 진입 시 서버에서 이미 시간이 지난 running 세션을 조회하면 `fetchSession`에서 `handleComplete`를 호출하는 동시에, 타이머 interval에서도 `remaining <= 0`을 감지해 `handleComplete`를 호출할 수 있음.

이 경우 완료 API(`PATCH /focus-sessions/:id`)가 중복으로 호출되어 이미 completed 상태인 세션에 또 completed 요청을 보내는 문제가 발생할 수 있습니다.
따라서 `isCompletingRef` 플래그를 추가해 중복 호출을 방지했습니다.

## 변경 사항
- `isCompletingRef` 플래그 추가
- `handleComplete` 진입 시 플래그 확인 → 이미 처리 중이면 즉시 return
- 완료 처리 성공 시 플래그를 `true`로 유지해 재호출 차단
- API 실패 시 플래그를 `false`로 초기화해 재시도 가능하도록 처리

## 영향 범위
- `useTimer.js` 수정
- 다른 기능 영향 없음

## 관련 이슈
- close #29 