### PR TITLE
feat: 스터디 상세 데이터 연동 및 localStorage 저장

### DIFF
--- a/src/components/Tag/Tag.module.css
+++ b/src/components/Tag/Tag.module.css
@@ -11,6 +11,7 @@
   border-radius: 3.125rem;
   width: max-content;
   flex-shrink: 0;
+  cursor: pointer;
 }
 
 .tag-point {
@@ -33,7 +34,7 @@
 }
 
 .tag-point-general {
-  padding: 0.5rem 0.75rem;
+  padding: 0.375rem 0.5rem;
   border: var(--tag-border);
   background: var(--white);
 }
@@ -94,6 +95,7 @@
 .text-general {
   font: var(--text-16-regular);
   color: var(--white);
+  line-height: 1;
 }
 
 .text-point-general {

--- a/src/pages/HomePage/Home.jsx
+++ b/src/pages/HomePage/Home.jsx
@@ -73,11 +73,9 @@ const Home = () => {
   }, [page, keyword, sortBy, order]);
 
   useEffect(() => {
-    const studies = localStorage.getItem(RECENT_STUDIES) || [];
+    const storaged = JSON.parse(localStorage.getItem(RECENT_STUDIES) || "[]");
 
-    console.log(studies);
-
-    setRecentStudies(studies);
+    setRecentStudies(storaged);
   }, []);
 
   const currentSort = SORTINGS.find(
@@ -116,7 +114,7 @@ const Home = () => {
                     title={study.title}
                     description={study.description}
                     days={diffDays}
-                    points={study.points}
+                    points={study.points ?? 0}
                     theme={study.theme}
                     emojis={study.emojis}
                   />

--- a/src/pages/HomePage/Home.module.css
+++ b/src/pages/HomePage/Home.module.css
@@ -152,6 +152,10 @@
   text-align: center;
 }
 
+.recent {
+  margin-top: 1.875rem;
+}
+
 .recent .notification {
   padding-block: 6.25rem 8.75rem;
 }

--- a/src/pages/StudyDetailPage/StudyDetail.jsx
+++ b/src/pages/StudyDetailPage/StudyDetail.jsx
@@ -20,6 +20,11 @@ const StudyDetail = () => {
   const navigate = useNavigate();
 
   const saveRecentStudy = (data) => {
+    const recentStudyTotalPoints =
+      data.focusSessions?.reduce((acc, cur) => acc + cur.earnedPoint, 0) ?? 0;
+
+    data.points = recentStudyTotalPoints;
+
     const storaged = JSON.parse(localStorage.getItem(RECENT_STUDIES) || "[]");
     const filtered = storaged.filter((s) => s.id !== data.id); // 이미 로컬스토리지에 해당 스터디가 저장되어 있는 경우 담지 않음
     filtered.unshift(data);

--- a/src/pages/StudyDetailPage/StudyDetail.jsx
+++ b/src/pages/StudyDetailPage/StudyDetail.jsx
@@ -1,33 +1,41 @@
 import React, { useEffect, useState } from "react";
-import styles from "./StudyDetail.module.css";
 import { useNavigate, useParams } from "react-router-dom";
+import { deleteStudy, getStudyDetail } from "../../api/studies";
+import useToast from "../../hooks/useToast";
 import Tag from "../../components/Tag/Tag";
 import BoxHeaderInfo from "../../components/BoxHeader/BoxHeaderInfo";
 import NavButton from "../../components/NavButton/NavButton";
-import { deleteStudy, getStudyDetail } from "../../api/studies";
 import PasswordModal from "./components/PasswordModal/PasswordModal";
 import Popup from "../../components/Popup/Popup";
 import SharingModal from "./components/SharingModal/SharingModal";
 import Toast from "../../components/Toast/Toast";
-import useToast from "../../hooks/useToast";
+import styles from "./StudyDetail.module.css";
 
 const StudyDetail = () => {
-  const { id } = useParams();
+  const { studyId } = useParams();
   const [study, setStudy] = useState(null); //가져온 스터디 객체를 저장할 변수
   const navigate = useNavigate();
 
   useEffect(() => {
     const fetchStudy = async () => {
       try {
-        const res = await getStudyDetail(id);
-        setStudy(res.data.data);
-        console.log(res.data.data);
+        const res = await getStudyDetail(studyId);
+        // console.log(res);
+        const { data } = res.data;
+
+        setStudy(data);
       } catch (error) {
         console.error(`데이터 조회 실패: ${error}`);
       }
     };
+
     fetchStudy();
-  }, [id]);
+  }, [studyId]);
+  // console.log(study);
+
+  // 획득 포인트 합계
+  const totalPoint =
+    study?.focusSessions?.reduce((acc, cur) => acc + cur.earnedPoint, 0) ?? 0;
 
   /* 공유/삭제/수정 버튼 관련 상태 변수 */
   const [showPwModal, setShowPwModal] = useState(false); //비밀번호 모달
@@ -108,8 +116,8 @@ const StudyDetail = () => {
         study && ( //비밀번호 모달 띄우기
           <PasswordModal
             setShowModal={setShowPwModal}
-            studyId={id}
-            title={study.title}
+            studyId={study?.id}
+            title={study?.title}
             confirmText={confirmText}
             onPasswordSuccess={onPasswordSuccess}
           />
@@ -126,7 +134,7 @@ const StudyDetail = () => {
       {showSharingModal && study && (
         <SharingModal
           setShowModal={setShowSharingModal}
-          title={study.title}
+          title={study?.title}
           url={window.location.href}
           onClickConfirm={onHandleSharing}
         />
@@ -178,7 +186,9 @@ const StudyDetail = () => {
           </div>
         </div>
         <div className={styles.headerTitle}>
-          <h2 className={styles.headline}>연우의 개발공장</h2>
+          <h2 className={styles.headline}>
+            {study?.nickname}의 {study?.title}
+          </h2>
 
           <div className={styles.btnGroup}>
             <NavButton
@@ -193,11 +203,8 @@ const StudyDetail = () => {
         </div>
 
         <div className={styles.headerInfo}>
-          <BoxHeaderInfo
-            title="소개"
-            info="Slow And Steady Wins The Race! 다들 오늘 하루도 화이팅 :)"
-          />
-          <BoxHeaderInfo type="point" info={310} />
+          <BoxHeaderInfo title="소개" info={study?.description} />
+          <BoxHeaderInfo type="point" info={totalPoint} />
         </div>
       </div>
 

--- a/src/pages/StudyDetailPage/StudyDetail.jsx
+++ b/src/pages/StudyDetailPage/StudyDetail.jsx
@@ -11,10 +11,25 @@ import SharingModal from "./components/SharingModal/SharingModal";
 import Toast from "../../components/Toast/Toast";
 import styles from "./StudyDetail.module.css";
 
+const RECENT_STUDIES = "recent_studies";
+
 const StudyDetail = () => {
+  const [loading, setLoading] = useState(true);
   const { studyId } = useParams();
   const [study, setStudy] = useState(null); //가져온 스터디 객체를 저장할 변수
   const navigate = useNavigate();
+
+  const saveRecentStudy = (data) => {
+    const storaged = JSON.parse(localStorage.getItem(RECENT_STUDIES) || "[]");
+    const filtered = storaged.filter((s) => s.id !== data.id); // 이미 로컬스토리지에 해당 스터디가 저장되어 있는 경우 담지 않음
+    filtered.unshift(data);
+    if (filtered.length > 3) {
+      // 3개를 넘어가면 제일 처음에 조회한 스터디 제거
+      filtered.pop();
+    }
+
+    localStorage.setItem(RECENT_STUDIES, JSON.stringify(filtered));
+  };
 
   useEffect(() => {
     const fetchStudy = async () => {
@@ -22,10 +37,13 @@ const StudyDetail = () => {
         const res = await getStudyDetail(studyId);
         // console.log(res);
         const { data } = res.data;
-
         setStudy(data);
+
+        saveRecentStudy(data); // localStorage 에 담기
       } catch (error) {
         console.error(`데이터 조회 실패: ${error}`);
+      } finally {
+        setLoading(false);
       }
     };
 
@@ -34,7 +52,7 @@ const StudyDetail = () => {
   // console.log(study);
 
   // 획득 포인트 합계
-  const totalPoint =
+  const totalPoints =
     study?.focusSessions?.reduce((acc, cur) => acc + cur.earnedPoint, 0) ?? 0;
 
   /* 공유/삭제/수정 버튼 관련 상태 변수 */
@@ -111,104 +129,110 @@ const StudyDetail = () => {
 
   return (
     <section className={styles.box}>
-      {toast && <Toast type={toast.type} text={toast.text} />}
-      {showPwModal &&
-        study && ( //비밀번호 모달 띄우기
-          <PasswordModal
-            setShowModal={setShowPwModal}
-            studyId={study?.id}
-            title={study?.title}
-            confirmText={confirmText}
-            onPasswordSuccess={onPasswordSuccess}
-          />
-        )}
-      {showDeletePopup && ( //정말 삭제하시겠습니까? 팝업
-        <Popup
-          setShowPopup={setShowDeletePopup}
-          hasCancel={true}
-          message="정말 삭제하시겠습니까?"
-          onClickConfirm={handleDelete}
-          onClickCancel={() => setShowDeletePopup(false)}
-        />
-      )}
-      {showSharingModal && study && (
-        <SharingModal
-          setShowModal={setShowSharingModal}
-          title={study?.title}
-          url={window.location.href}
-          onClickConfirm={onHandleSharing}
-        />
-      )}
-      <div className={styles.boxHeader}>
-        <div className={styles.headerTop}>
-          <div className={styles.management}>
-            <ul>
-              <li>
-                <button onClick={onClickSharing}>공유하기</button>
-              </li>
-              <li>
-                <button onClick={onClickModify}>수정하기</button>
-              </li>
-              <li>
-                <button onClick={onClickDelete}>스터디 삭제하기</button>
-              </li>
-            </ul>
-          </div>
+      {loading ? (
+        <p className={styles.notification}>스터디 조회중...</p>
+      ) : (
+        <>
+          {toast && <Toast type={toast.type} text={toast.text} />}
+          {showPwModal &&
+            study && ( //비밀번호 모달 띄우기
+              <PasswordModal
+                setShowModal={setShowPwModal}
+                studyId={study?.id}
+                title={study?.title}
+                confirmText={confirmText}
+                onPasswordSuccess={onPasswordSuccess}
+              />
+            )}
+          {showDeletePopup && ( //정말 삭제하시겠습니까? 팝업
+            <Popup
+              setShowPopup={setShowDeletePopup}
+              hasCancel={true}
+              message="정말 삭제하시겠습니까?"
+              onClickConfirm={handleDelete}
+              onClickCancel={() => setShowDeletePopup(false)}
+            />
+          )}
+          {showSharingModal && study && (
+            <SharingModal
+              setShowModal={setShowSharingModal}
+              title={study?.title}
+              url={window.location.href}
+              onClickConfirm={onHandleSharing}
+            />
+          )}
+          <div className={styles.boxHeader}>
+            <div className={styles.headerTop}>
+              <div className={styles.management}>
+                <ul>
+                  <li>
+                    <button onClick={onClickSharing}>공유하기</button>
+                  </li>
+                  <li>
+                    <button onClick={onClickModify}>수정하기</button>
+                  </li>
+                  <li>
+                    <button onClick={onClickDelete}>스터디 삭제하기</button>
+                  </li>
+                </ul>
+              </div>
 
-          <div className={styles.emoji}>
-            <div className={styles.emojiTop3}>
-              <Tag
-                variant="general"
-                type="emoji"
-                theme="dark"
-                emojiIcon="👩🏻‍💻"
-                count={37}
-              />
-              <Tag
-                variant="general"
-                type="emoji"
-                theme="dark"
-                emojiIcon="👍"
-                count={11}
-              />
-              <Tag
-                variant="general"
-                type="emoji"
-                theme="dark"
-                emojiIcon="🤩"
-                count={9}
-              />
+              <div className={styles.emoji}>
+                <div className={styles.emojiTop3}>
+                  <Tag
+                    variant="general"
+                    type="emoji"
+                    theme="dark"
+                    emojiIcon="👩🏻‍💻"
+                    count={37}
+                  />
+                  <Tag
+                    variant="general"
+                    type="emoji"
+                    theme="dark"
+                    emojiIcon="👍"
+                    count={11}
+                  />
+                  <Tag
+                    variant="general"
+                    type="emoji"
+                    theme="dark"
+                    emojiIcon="🤩"
+                    count={9}
+                  />
+                </div>
+
+                <button className={styles.addEmoji}>
+                  <i className="ic smile"></i> 추가
+                </button>
+              </div>
+            </div>
+            <div className={styles.headerTitle}>
+              <h2 className={styles.headline}>
+                {study?.nickname}의 {study?.title}
+              </h2>
+
+              <div className={styles.btnGroup}>
+                <NavButton
+                  label="오늘의 습관"
+                  onClick={() => navigate(`/studies/${studyId}/habits`)}
+                />
+                <NavButton
+                  label="오늘의 집중"
+                  onClick={() => navigate(`/studies/${studyId}/focus`)}
+                />
+              </div>
             </div>
 
-            <button className={styles.addEmoji}>
-              <i className="ic smile"></i> 추가
-            </button>
+            <div className={styles.headerInfo}>
+              <BoxHeaderInfo title="소개" info={study?.description} />
+              <BoxHeaderInfo type="point" info={totalPoints} />
+            </div>
           </div>
-        </div>
-        <div className={styles.headerTitle}>
-          <h2 className={styles.headline}>
-            {study?.nickname}의 {study?.title}
-          </h2>
 
-          <div className={styles.btnGroup}>
-            <NavButton
-              label="오늘의 습관"
-              onClick={() => navigate(`/studies/${studyId}/habits`)}
-            />
-            <NavButton
-              label="오늘의 집중"
-              onClick={() => navigate(`/studies/${studyId}/focus`)}
-            />
-          </div>
-        </div>
-
-        <div className={styles.headerInfo}>
-          <BoxHeaderInfo title="소개" info={study?.description} />
-          <BoxHeaderInfo type="point" info={totalPoint} />
-        </div>
-      </div>
-
-      <div className={styles.todayHabits}>습관 데이터 불러올 자리</div>
+          <div className={styles.todayHabits}>습관 데이터 불러올 자리</div>
+        </>
+      )}
     </section>
   );
 };

--- a/src/pages/StudyDetailPage/StudyDetail.module.css
+++ b/src/pages/StudyDetailPage/StudyDetail.module.css
@@ -1,9 +1,17 @@
 .box {
-  width: min(100%, 1200px);
-  padding: 40px;
+  width: min(100%, 75rem);
+  padding: 2.5rem;
   margin-inline: auto;
   background-color: var(--white);
-  border-radius: 20px;
+  border-radius: 1.25rem;
+}
+
+.notification {
+  grid-column: 1 / span 3;
+  padding-block: 1.25rem;
+  font: var(--text-20-medium);
+  color: var(--gray-500);
+  text-align: center;
 }
 
 .boxHeader .headerTop,
@@ -19,7 +27,7 @@
 }
 
 .boxHeader .headerTitle {
-  margin-top: 24px;
+  margin-top: 1.5rem;
 }
 
 .boxHeader .headline {
@@ -31,21 +39,21 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
+  gap: 0.5rem;
 }
 
 .emojiTop3 {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 0.25rem;
 }
 
 .emoji .addEmoji {
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 5px;
-  padding: 6px 8px;
+  gap: 0.3125rem;
+  padding: 6px-0.375rem 0.5rem;
   background-color: var(--white);
   border: 1px solid var(--gray-300);
   border-radius: 5em;
@@ -61,8 +69,8 @@
 
 .management ul li:not(:first-child) {
   position: relative;
-  padding-left: 16px;
-  margin-left: 16px;
+  padding-left: 1rem;
+  margin-left: 1rem;
 }
 
 .management ul li:not(:first-child)::before {
@@ -71,8 +79,8 @@
   top: 50%;
   left: 0;
   width: 1px;
-  height: 16px;
-  margin-top: -8px;
+  height: 1rem;
+  margin-top: -0.5rem;
   background-color: var(--green-text);
 }
 
@@ -93,19 +101,19 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 16px;
+  gap: 1rem;
 }
 
 .btnOpenModal {
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 4px;
-  min-width: 144px;
-  padding-block: 12px;
+  gap: 0.25rem;
+  min-width: 9rem;
+  padding-block: 0.75rem;
   background-color: var(--white);
   border: 1px solid var(--gray-300);
-  border-radius: 15px;
+  border-radius: 0.9375rem;
   font: var(--text-16-medium);
   color: var(--gray-500);
 }
@@ -116,16 +124,16 @@
 }
 
 .headerInfo {
-  margin-top: 16px;
+  margin-top: 1rem;
 }
 
 .todayHabits {
-  margin-top: 40px;
+  margin-top: 2.5rem;
 }
 
 @media all and (max-width: 744px) {
   .box {
-    padding: 24px;
+    padding: 1.5rem;
   }
 
   .boxHeader .headerTop,
@@ -134,7 +142,7 @@
   }
 
   .btnGroup {
-    margin-top: 16px;
+    margin-top: 1rem;
   }
 
   .management ul {
@@ -142,22 +150,22 @@
   }
 
   .management ul li:not(:first-child) {
-    padding-left: 8px;
-    margin-left: 8px;
+    padding-left: 0.5rem;
+    margin-left: 0.5rem;
   }
 
   .emoji {
-    margin-top: 16px;
+    margin-top: 1rem;
   }
 
   .todayHabits {
-    margin-top: 24px;
+    margin-top: 1.5rem;
   }
 }
 
 @media all and (max-width: 375px) {
   .box {
-    padding: 16px;
+    padding: 1rem;
   }
 
   .boxHeader .headline {
@@ -165,8 +173,8 @@
   }
 
   .management ul li:not(:first-child)::before {
-    height: 12px;
-    margin-top: -6px;
+    height: 0.75rem;
+    margin-top: -0.375rem;
   }
   .management button {
     font: var(--text-12-medium);

--- a/src/pages/StudyDetailPage/StudyDetail.module.css
+++ b/src/pages/StudyDetailPage/StudyDetail.module.css
@@ -53,12 +53,13 @@
   justify-content: center;
   align-items: center;
   gap: 0.3125rem;
-  padding: 6px-0.375rem 0.5rem;
+  padding: 0.375rem 0.5rem;
   background-color: var(--white);
   border: 1px solid var(--gray-300);
   border-radius: 5em;
   font: var(--text-16-medium);
   color: var(--black);
+  line-height: 1.2;
 }
 
 .management ul {


### PR DESCRIPTION
## 개요

상세페이지 접속시 패스 파라미터로 전달받은 studyId 값으로 스터디 테이블에서 데이터를 받아와서 상세페이지 UI 구현

상세페이지 접속시 localStorage 에 저장
- 최대 3개까지 저장을 하고, 최근 조회한 스터디가 3개를 넘어갈 경우 FIFO 처리방법으로 가장 먼저 조회했던 스터디 데이터를 삭제하고 최근 스터디를 저장
- 이미 방문했던 스터디의 상세페이지를 재접속시 중복 데이터 저장을 방지하기 위해 동일한 데이터가 존재하면 삭제하고, 가장 최근 스터디 데이터로 다시 저장

## 발견된 이슈(?)
- 스터디 상세 > 오늘의 집중 이동 > 포인트 획득 > 홈 이동, 이러한 루트로 홈(스터디 목록) 접근시 최근 조회한 스터디에 바로 이전에 획득한 포인트 반영이 안됨
  > 원인: 최근 조회한 스터디는 db 의 데이터를 가져와서 계산하는 방식이 아닌 상세 페이지 접속시에만 localStorage 에 담기는 데이터를 가져와서 출력하기 때문에 집중 페이지에서 포인트를 획득 후 홈으로 이동시에는 획득 포인트가 반영되지 않는 이슈
  
  > 해결책: 최근 조회한 스터디도 db 화를 해야하나? 집중 페이지에서 포인트 획득시 localStorage 에 저장된 데이터를 갱신시켜줘야하나? 여러 방법이 있을 것 같은데 현재 상태에서 어떤 방법이 나은지는 고민 필요

## 영향 범위

스터디 목록(Home.jsx)에 조회한 스터디 출력
Tag 컴포넌트 스타일 수정

## 코드리뷰

1. 포인트를 가져오는 방식이 목록 조회에서는 백에서 합계를 구해서 넘겨주는데, 현재 상세는 프론트에서 합계를 구해서 출력하고 있는 상태로, 상세도 동일하게 백에서 합계를 구해서 넘겨주는게 나은지 궁금합니다.

2. 최근 조회한 스터디를 상세 페이지 접속시 localStorage 에 담기게 구현했는데, user 기능이 없는 상태에서 누가 최근 조회한 건지를 판별하기 위해 ip 를 기준으로 db 화해서 최근 3개의 데이터만 가져오는게 나은지 고민을 했었는데, 공유기를 사용하는 환경에서는 ip 도 중복될 수 있는 여지가 있어서 ip 를 pk 로 사용하는 건 무리일 것 같은데 이럴 때 최근 조회한 스터디를 작업하는 방법이 궁금합니다. ( 집중페이지에서 포인트 획득 후 바로 메인으로 이동시 최근 조회한 스터디에 획득 포인트는 반영되지 않은 채로 출력이 되는 이슈로 인해... db 화를 생각하게 되었습니다. )

궁금한 건 많았는데... 일단 크게 생각나는건 이 정도입니다;;

## 관련 이슈

- close #25 
