### PR TITLE
feat: 집중 페이지 재진입 시 타이머 재개 여부 선택 팝업 추가

### DIFF
--- a/src/components/Popup/Popup.jsx
+++ b/src/components/Popup/Popup.jsx
@@ -9,6 +9,8 @@ const Popup = ({
   message,
   onClickConfirm,
   onClickCancel,
+  confirmText = "확인",
+  cancelText = "취소",
 }) => {
   return (
     <div className={styles.overlay}>
@@ -22,7 +24,7 @@ const Popup = ({
           {hasCancel && (
             <Button
               variant="cancel"
-              label="취소"
+              label={cancelText}
               onClick={() => {
                 setShowPopup(false);
                 //취소 버튼 클릭 시 수행할 작업 (아마 거의 쓰일 일이 없을듯 싶지만?)
@@ -33,7 +35,7 @@ const Popup = ({
           )}
           <Button
             variant="create"
-            label="확인"
+            label={confirmText}
             onClick={() => {
               // 확인 버튼 클릭 시 수행할 작업
               setShowPopup(false);

--- a/src/hooks/useTimer.js
+++ b/src/hooks/useTimer.js
@@ -17,7 +17,9 @@ function useTimer(studyId, durationSec) {
   const [timerStatus, setTimerStatus] = useState(TIMER_STATUS.IDLE);
   const [timeLeft, setTimeLeft] = useState(durationSec);
   const [earnedPoint, setEarnedPoint] = useState(0);
-  const [sessionDuration, setSessionDuration] = useState(null); // 페이지 재진입 시 타이머 설정 시간 표시
+  // 페이지 재진입 시 타이머 설정 시간 표시용
+  const [sessionDuration, setSessionDuration] = useState(null);
+  // 페이지 재진입 시 타이머가 paused 상태인지 여부 (재개 팝업 표시용)
   const [shouldShowResumePopup, setShouldShowResumePopup] = useState(false);
 
   const endTimeRef = useRef(null); // Date.now와 종료 시각을 기준으로 남은 시간 계산
@@ -27,7 +29,7 @@ function useTimer(studyId, durationSec) {
 
   const { toast, showToast } = useToast();
 
-  // 타이머 완료 처리
+  // 타이머 완료 처리: failed=true일 경우 포인트 미지급
   const handleComplete = useCallback(
     async ({ failed = false } = {}) => {
       if (isCompletingRef.current) return;
@@ -99,7 +101,7 @@ function useTimer(studyId, durationSec) {
           setTimerStatus(TIMER_STATUS.PAUSED);
           setSessionDuration(data.durationMin * 60);
 
-          // 페이지 재진입에서만 popup
+          // 타이머가 paused 상태안 경우에만 타이머 재개 여부 팝업 표시
           setShouldShowResumePopup(true);
         }
       } catch (e) {

--- a/src/hooks/useTimer.js
+++ b/src/hooks/useTimer.js
@@ -11,6 +11,7 @@ export const TIMER_STATUS = {
   RUNNING: "running", // 진행 중
   PAUSED: "paused", // 일시 정지
   COMPLETED: "completed", // 종료
+  FAILED: "failed",
 };
 
 function useTimer(studyId, durationSec) {
@@ -31,23 +32,22 @@ function useTimer(studyId, durationSec) {
 
   // 타이머 완료 처리: failed=true일 경우 포인트 미지급
   const handleComplete = useCallback(
-    async ({ failed = false } = {}) => {
+    async ({ action = TIMER_STATUS.COMPLETED } = {}) => {
       if (isCompletingRef.current) return;
       isCompletingRef.current = true;
 
       try {
         const res = await updateFocusSession(studyId, sessionIdRef.current, {
-          action: TIMER_STATUS.COMPLETED,
-          ...(failed && { status: "failed" }),
+          action,
         });
 
         const { data } = res.data;
 
-        if (!failed) {
+        if (action === TIMER_STATUS.COMPLETED) {
           const pointResult = data.earnedPoint ?? 0;
           setEarnedPoint(pointResult);
           showToast("success", "포인트를 획득했습니다!", pointResult);
-        } else {
+        } else if (action === TIMER_STATUS.FAILED) {
           showToast("warning", "집중이 종료되어 포인트가 지급되지 않습니다.");
         }
 
@@ -55,6 +55,7 @@ function useTimer(studyId, durationSec) {
       } catch (e) {
         isCompletingRef.current = false;
         showToast("warning", e.userMessage);
+        console.log(e);
       }
     },
     [showToast, studyId],

--- a/src/hooks/useTimer.js
+++ b/src/hooks/useTimer.js
@@ -18,6 +18,7 @@ function useTimer(studyId, durationSec) {
   const [timeLeft, setTimeLeft] = useState(durationSec);
   const [earnedPoint, setEarnedPoint] = useState(0);
   const [sessionDuration, setSessionDuration] = useState(null); // 페이지 재진입 시 타이머 설정 시간 표시
+  const [shouldShowResumePopup, setShouldShowResumePopup] = useState(false);
 
   const endTimeRef = useRef(null); // Date.now와 종료 시각을 기준으로 남은 시간 계산
   const intervalIdRef = useRef(null); // 현재 실행 중인 Interval의 ID
@@ -27,26 +28,35 @@ function useTimer(studyId, durationSec) {
   const { toast, showToast } = useToast();
 
   // 타이머 완료 처리
-  const handleComplete = useCallback(async () => {
-    if (isCompletingRef.current) return;
-    isCompletingRef.current = true;
+  const handleComplete = useCallback(
+    async ({ failed = false } = {}) => {
+      if (isCompletingRef.current) return;
+      isCompletingRef.current = true;
 
-    try {
-      const res = await updateFocusSession(studyId, sessionIdRef.current, {
-        action: TIMER_STATUS.COMPLETED,
-      });
+      try {
+        const res = await updateFocusSession(studyId, sessionIdRef.current, {
+          action: TIMER_STATUS.COMPLETED,
+          ...(failed && { status: "failed" }),
+        });
 
-      const { data } = res.data;
+        const { data } = res.data;
 
-      const pointResult = data.earnedPoint ?? 0;
-      setEarnedPoint(pointResult);
-      setTimerStatus(data.status);
-      showToast("success", "포인트를 획득했습니다!", pointResult);
-    } catch (e) {
-      isCompletingRef.current = false;
-      showToast("warning", e.userMessage);
-    }
-  }, [showToast, studyId]);
+        if (!failed) {
+          const pointResult = data.earnedPoint ?? 0;
+          setEarnedPoint(pointResult);
+          showToast("success", "포인트를 획득했습니다!", pointResult);
+        } else {
+          showToast("warning", "집중이 종료되어 포인트가 지급되지 않습니다.");
+        }
+
+        setTimerStatus(data.status);
+      } catch (e) {
+        isCompletingRef.current = false;
+        showToast("warning", e.userMessage);
+      }
+    },
+    [showToast, studyId],
+  );
 
   // 페이지 진입 시 세션 조회
   useEffect(() => {
@@ -84,14 +94,13 @@ function useTimer(studyId, durationSec) {
               1000,
           );
 
-          await updateFocusSession(studyId, sessionIdRef.current, {
-            action: TIMER_STATUS.RUNNING,
-          });
-
-          endTimeRef.current = new Date(Date.now() + remaining * 1000);
+          endTimeRef.current = null;
           setTimeLeft(remaining > 0 ? remaining : 0);
-          setTimerStatus(TIMER_STATUS.RUNNING);
+          setTimerStatus(TIMER_STATUS.PAUSED);
           setSessionDuration(data.durationMin * 60);
+
+          // 페이지 재진입에서만 popup
+          setShouldShowResumePopup(true);
         }
       } catch (e) {
         showToast("warning", e.userMessage);
@@ -179,6 +188,10 @@ function useTimer(studyId, durationSec) {
     }
   };
 
+  const complete = (options) => {
+    handleComplete(options);
+  };
+
   return {
     timerStatus,
     timeLeft,
@@ -186,8 +199,10 @@ function useTimer(studyId, durationSec) {
     start,
     pause,
     resume,
+    complete,
     toast,
     sessionDuration,
+    shouldShowResumePopup,
   };
 }
 

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -22,10 +22,13 @@ function Focus() {
   const [isEditing, setIsEditing] = useState(false);
   const [inputMin, setInputMin] = useState("25");
   const [inputSec, setInputSec] = useState("00");
+  // 재개 여부 선택 팝업 상태
   const [showResumePopup, setShowResumePopup] = useState(false);
+  // 종료 재확인 팝업 상태
   const [showStopConfirmPopup, setShowStopConfirmPopup] = useState(false);
 
-  const minInputRef = useRef(null); // 직접입력 버튼 클릭 시 분 input에 자동으로 포커스줄 용도
+  // 직접입력 버튼 클릭 시 분 input 포커스용 ref
+  const minInputRef = useRef(null);
 
   // 스터디 정보 조회 (추후 전역 상태로 수정 예정)
   useEffect(() => {
@@ -90,17 +93,19 @@ function Focus() {
     setDurationSec(Math.max(1, m * 60 + s));
   };
 
+  // 재진입 팝업에서 "계속 진행" 선택 시 일시정지된 타이머를 재시작하고 팝업 닫기
   const handleResumeConfirm = () => {
     resume();
     setShowResumePopup(false);
   };
 
+  // 재진입 팝업에서 "종료" 선택 시 바로 종료하지 않고 종료 재확인 팝업 노출
   const handleStopClick = () => {
-    //complete({ failed: true });
     setShowResumePopup(false);
     setShowStopConfirmPopup(true);
   };
 
+  // 종료 재확인 팝업에서 "종료" 선택 시 포인트 지급 없이 타이머 종료 처리
   const handleStopConfirm = () => {
     complete({ failed: true });
     setShowStopConfirmPopup(false);
@@ -112,6 +117,7 @@ function Focus() {
         <Toast type={toast.type} text={toast.text} point={toast.point} />
       )}
 
+      {/* 페이지 재진입 시 타이머가 paused 상태일 경우 표시되는 재개 여부 선택 팝업 */}
       {showResumePopup && (
         <ResumeConfirmPopup
           setShow={setShowResumePopup}
@@ -120,6 +126,7 @@ function Focus() {
         />
       )}
 
+      {/* 재진입 팝업에서 종료 선택 시 표시되는 최종 종료 확인 팝업 */}
       {showStopConfirmPopup && (
         <StopConfirmPopup
           setShow={setShowStopConfirmPopup}

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -4,6 +4,8 @@ import { getStudyDetail } from "../../api/studies";
 import BoxHeaderInfo from "../../components/BoxHeader/BoxHeaderInfo";
 import NavButton from "../../components/NavButton/NavButton";
 import Toast from "../../components/Toast/Toast";
+import ResumeConfirmPopup from "./components/ResumeConfirmPopup";
+import StopConfirmPopup from "./components/StopConfirmPopup";
 import useTimer, { TIMER_STATUS } from "../../hooks/useTimer";
 import formatTime from "./formatTime";
 import styles from "./Focus.module.css";
@@ -20,6 +22,8 @@ function Focus() {
   const [isEditing, setIsEditing] = useState(false);
   const [inputMin, setInputMin] = useState("25");
   const [inputSec, setInputSec] = useState("00");
+  const [showResumePopup, setShowResumePopup] = useState(false);
+  const [showStopConfirmPopup, setShowStopConfirmPopup] = useState(false);
 
   const minInputRef = useRef(null); // 직접입력 버튼 클릭 시 분 input에 자동으로 포커스줄 용도
 
@@ -41,14 +45,20 @@ function Focus() {
     start,
     pause,
     resume,
+    complete,
     toast,
     sessionDuration,
+    shouldShowResumePopup,
   } = useTimer(studyId, durationSec);
 
   // 페이지 재진입 시 타이머 설정 시간 표시
   useEffect(() => {
     if (sessionDuration) setDurationSec(sessionDuration);
   }, [sessionDuration]);
+
+  useEffect(() => {
+    if (shouldShowResumePopup) setShowResumePopup(true);
+  }, [shouldShowResumePopup]);
 
   // 타이머 상태: 진행/중지/완료/시작 전
   const isRunning = timerStatus === TIMER_STATUS.RUNNING;
@@ -80,10 +90,42 @@ function Focus() {
     setDurationSec(Math.max(1, m * 60 + s));
   };
 
+  const handleResumeConfirm = () => {
+    resume();
+    setShowResumePopup(false);
+  };
+
+  const handleStopClick = () => {
+    //complete({ failed: true });
+    setShowResumePopup(false);
+    setShowStopConfirmPopup(true);
+  };
+
+  const handleStopConfirm = () => {
+    complete({ failed: true });
+    setShowStopConfirmPopup(false);
+  };
+
   return (
     <section className={styles.container}>
       {toast && (
         <Toast type={toast.type} text={toast.text} point={toast.point} />
+      )}
+
+      {showResumePopup && (
+        <ResumeConfirmPopup
+          setShow={setShowResumePopup}
+          onResume={handleResumeConfirm}
+          onStop={handleStopClick}
+        />
+      )}
+
+      {showStopConfirmPopup && (
+        <StopConfirmPopup
+          setShow={setShowStopConfirmPopup}
+          onResume={handleResumeConfirm}
+          onStop={handleStopConfirm}
+        />
       )}
 
       {/* 스터디 정보 표시 */}

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -107,7 +107,7 @@ function Focus() {
 
   // 종료 재확인 팝업에서 "종료" 선택 시 포인트 지급 없이 타이머 종료 처리
   const handleStopConfirm = () => {
-    complete({ failed: true });
+    complete({ action: "failed" });
     setShowStopConfirmPopup(false);
   };
 

--- a/src/pages/FocusPage/components/ResumeConfirmPopup.jsx
+++ b/src/pages/FocusPage/components/ResumeConfirmPopup.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import Popup from "../../../components/Popup/Popup";
+
+function ResumeConfirmPopup({ setShow, onResume, onStop }) {
+  return (
+    <Popup
+      message="이전에 진행 중이던 집중이 있습니다. 계속 진행하시겠습니까?"
+      hasCancel
+      setShowPopup={setShow}
+      onClickConfirm={onResume}
+      onClickCancel={onStop}
+      confirmText="계속 진행"
+      cancelText="종료"
+    />
+  );
+}
+
+export default ResumeConfirmPopup;

--- a/src/pages/FocusPage/components/StopConfirmPopup.jsx
+++ b/src/pages/FocusPage/components/StopConfirmPopup.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import Popup from "../../../components/Popup/Popup";
+
+function StopConfirmPopup({ setShow, onResume, onStop }) {
+  return (
+    <Popup
+      message="지금 종료 시 포인트가 지급되지 않습니다. 종료하시겠습니까?"
+      hasCancel
+      setShowPopup={setShow}
+      confirmText="종료"
+      cancelText="계속 진행"
+      onClickConfirm={onStop}
+      onClickCancel={onResume}
+    />
+  );
+}
+
+export default StopConfirmPopup;


### PR DESCRIPTION

## 개요
현재는 타이머를 일시정지한 상태에서 페이지를 벗어난 뒤 다시 집중 페이지에 진입할 경우, 자동으로 타이머가 재시작되고 있다.
페이지 재진입 시 자동 재시작이 아닌 제개 여부 선택 팝업을 노출하고 사용자가 직접 "계속 진행" 또는 "종료"를 선택할 수 있도록 변경했다. 
"종료"를 선택할 경우 정말 종료할 것인지 묻는 팝업을 노출하고 사용자가 "종료"를 선택할 경우 포인트는 지급되지 않은 상태로 타이머가 종료되도록 구현했다.

## 변경 사항
- paused 상태에서 페이지 재진입 시 자동 재시작 제거
- 재진입 시 재개 여부 선택 팝업 추가 (ResumeConfirmPopup)
- 종료 선택 시 최종 종료 확인 팝업 추가 (StopConfirmPopup)
- "계속 진행" 선택 시 타이머 재시작 처리
- "종료" 선택 시 세션 상태 변경 API(₩PATCH /focus-session`) 호출 (`action=failed` 전달)
- Popup 컴포넌트 버튼 텍스트 커스터마이징 props 추가

## 스크린샷 (UI 변경 시)
### 페이지 진입 시 일시정지한 타이머가 있는 경우
<img width="1314" height="952" alt="localhost_5173_studies_22_focus" src="https://github.com/user-attachments/assets/a4aeda45-1b94-4829-8911-1dbc3c9db4cb" />

### "종료" 선택한 경우: 최종 종료 확인 팝업이 표시됨
<img width="1314" height="952" alt="localhost_5173_studies_22_focus (1)" src="https://github.com/user-attachments/assets/bcd8115a-6fba-40a7-b19b-e9c3533f8977" />

###  최종 종료 확인 팝업에서 "종료" 선택한 경우: 토스트 표시되며 종료
<img width="1153" height="830" alt="스크린샷 2026-04-20 오전 10 17 52" src="https://github.com/user-attachments/assets/b2d957de-fb68-411d-ba92-acf0ffeb4191" />

### "계속 진행" 선택한 경우: 타이머가 진행됨
<img width="1314" height="952" alt="localhost_5173_studies_22_focus (2)" src="https://github.com/user-attachments/assets/9447507d-1018-442e-bad8-0ddda43f8cc4" />

## 영향 범위
- Popup 컴포넌트에  `confirmText`, `cancelText` props를 추가해 버튼 내 텍스트 수정 가능 

## 관련 이슈
- close #31 
