### PR TITLE
fix: 집중 세션 API durationSec 변경에 따른 프론트 연동 수정

### DIFF
--- a/src/hooks/useTimer.js
+++ b/src/hooks/useTimer.js
@@ -88,7 +88,7 @@ function useTimer(studyId, durationSec) {
           endTimeRef.current = new Date(data.endTime);
           setTimeLeft(remaining);
           setTimerStatus(TIMER_STATUS.RUNNING);
-          setSessionDuration(data.durationMin * 60);
+          setSessionDuration(data.durationSec);
         } else if (data.status === TIMER_STATUS.PAUSED) {
           // paused: endTime - pausedAt 으로 남은 시간 계산
           const remaining = Math.ceil(
@@ -100,7 +100,7 @@ function useTimer(studyId, durationSec) {
           endTimeRef.current = null;
           setTimeLeft(remaining > 0 ? remaining : 0);
           setTimerStatus(TIMER_STATUS.PAUSED);
-          setSessionDuration(data.durationMin * 60);
+          setSessionDuration(data.durationSec);
 
           // 타이머가 paused 상태안 경우에만 타이머 재개 여부 팝업 표시
           setShouldShowResumePopup(true);
@@ -145,13 +145,13 @@ function useTimer(studyId, durationSec) {
   const start = async () => {
     try {
       const res = await createFocusSession(studyId, {
-        durationMin: Math.ceil(durationSec / 60),
+        durationSec,
       });
 
       const { data } = res.data;
 
       sessionIdRef.current = data.id;
-      endTimeRef.current = new Date(Date.now() + durationSec * 1000);
+      endTimeRef.current = new Date(data.endTime);
       setTimeLeft(durationSec);
       setTimerStatus(data.status);
     } catch (e) {
@@ -168,7 +168,6 @@ function useTimer(studyId, durationSec) {
 
       const { data } = res.data;
 
-      endTimeRef.current = null;
       setTimerStatus(data.status);
       showToast("warning", "집중이 중단되었습니다.");
     } catch (e) {
@@ -178,13 +177,17 @@ function useTimer(studyId, durationSec) {
 
   const resume = async () => {
     try {
+      const requestedAt = Date.now(); // 네트워크 요청 직전 시각
+
       const res = await updateFocusSession(studyId, sessionIdRef.current, {
         action: TIMER_STATUS.RUNNING,
       });
 
       const { data } = res.data;
 
-      endTimeRef.current = new Date(Date.now() + timeLeft * 1000);
+      // 요청~응답 사이 경과 시간만큼 endTime을 앞당겨 네트워크 딜레이 보정
+      const elapsed = Date.now() - requestedAt;
+      endTimeRef.current = new Date(new Date(data.endTime).getTime() - elapsed);
       setTimerStatus(data.status);
     } catch (e) {
       showToast("warning", e.userMessage);


### PR DESCRIPTION
## 개요
백엔드에서 집중 시간을 `durationSec`(초 단위)으로 받도록 수정됨에 따라 프론트 연동 코드를 수정합니다.
이를 통해 사용자가 설정한 시간이 정확하게 서버에 저장되어 페이지 재진입 시에도 남은 시간이 정상적으로 복원됩니다. 또한 클라이언트에서 임시로 `endTime`을 계산하던 코드를 제거합니다.


## 변경 사항
- 세션 생성 API 요청 body `durationMin` → `durationSec` 변경
- 서버 응답 `data.endTime` 그대로 사용 (클라이언트 임시 계산 코드 제거)
- 페이지 재진입 시 설정 시간 복원 `data.durationMin * 60` → `data.durationSec` 변경

## 영향 범위
- `useTimer.js` 수정
- 다른 기능 영향 없음

## 관련 이슈
- close #37
- Follow-up of #26 (타이머 시간 설정 기능 PR에서 명시된 미구현 사항)
