### PR TITLE
feat: 페이지 재진입 시 running 상태 타이머도 재개 여부 팝업 표시

### DIFF
--- a/src/hooks/useTimer.js
+++ b/src/hooks/useTimer.js
@@ -79,16 +79,24 @@ function useTimer(studyId, durationSec) {
             (new Date(data.endTime).getTime() - Date.now()) / 1000,
           );
 
+          // 타이머가 돌아가는 도중 페이지를 나갔는데, 돌아왔을 때 타이머 시간이 다 지나버린 경우
           if (remaining <= 0) {
-            // 서버에선 running인데 시간이 이미 지난 경우
             handleComplete();
             return;
           }
 
-          endTimeRef.current = new Date(data.endTime);
+          // 자동 재시작 대신 paused로 전환 후 팝업 표시
+          await updateFocusSession(studyId, data.id, {
+            action: TIMER_STATUS.PAUSED,
+          });
+
+          endTimeRef.current = null;
           setTimeLeft(remaining);
-          setTimerStatus(TIMER_STATUS.RUNNING);
+          setTimerStatus(TIMER_STATUS.PAUSED);
+          console.log("data.durationSec:", data.durationSec);
           setSessionDuration(data.durationSec);
+          console.log("sessionDuration 세팅 완료");
+          setShouldShowResumePopup(true);
         } else if (data.status === TIMER_STATUS.PAUSED) {
           // paused: endTime - pausedAt 으로 남은 시간 계산
           const remaining = Math.ceil(
@@ -100,7 +108,9 @@ function useTimer(studyId, durationSec) {
           endTimeRef.current = null;
           setTimeLeft(remaining > 0 ? remaining : 0);
           setTimerStatus(TIMER_STATUS.PAUSED);
+          console.log("data.durationSec:", data.durationSec);
           setSessionDuration(data.durationSec);
+          console.log("sessionDuration 세팅 완료");
 
           // 타이머가 paused 상태안 경우에만 타이머 재개 여부 팝업 표시
           setShouldShowResumePopup(true);


### PR DESCRIPTION
## 개요
기존에는 paused 상태로 재진입 시에만 재개 여부 팝업을 표시했으나, running 상태로 재진입 시에도 자동 재시작 대신 팝업을 표시하도록 변경합니다.
사용자가 타이머를 켜놓고 페이지를 나간 경우, 의도적으로 나간 건지 실수로 나간 건지 알 수 없기 때문에 자동 재시작보다는 사용자가 직접 재개 여부를 선택할 수 있도록 하는 것이 더 자연스러운 UX라고 판단했습니다.

## 변경 사항
- 페이지 재진입 시 running 상태일 경우 서버에 paused 요청 후 팝업 표시
- 타이머 시간이 이미 지난 경우(remaining <= 0) 자동 완료 처리
    - 타이머 진행 중 나갔다가 돌아왔을 때 시간이 이미 지난 경우
    - 타이머를 켜놓고 나갔으면 사용자가 집중하고 있었다고 간주하고 자동으로 완료 처리
- running/paused 재진입 흐름 통일

## 영향 범위
- `useTimer.js` 수정
- 다른 기능 영향 없음

## 관련 이슈
- close #40
- Follow-up of #31