### PR TITLE
feat: 스터디 내 다중 세션 지원 및 선택 UI 추가

### DIFF
--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -16,18 +16,20 @@
 
 .modalContainer {
   border-radius: 20px;
-  border: 1px solid var(--gray-gray_DDDDDD, #ddd);
-  background: #fff;
+  border: 1px solid var(--gray-300);
+  background-color: var(--white);
   box-shadow: 0rem 0px 15px rgba(0, 0, 0, 0.1);
 
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 1.5rem;
+  width: 40.5rem;
   padding: 2.5rem 1.5rem;
 }
+
 .modalTitle {
-  color: var(--black-black_414141, #414141);
+  color: var(--black);
   text-align: center;
   font-family: Pretendard;
   font-size: 1.5rem;
@@ -56,8 +58,9 @@
   align-items: center; /* 나가기 버튼을 중간에 두기 위함. */
   justify-content: center;
 }
+
 .exitBtn {
-  color: #578246;
+  color: var(--brand);
   text-align: right;
   font-family: Pretendard;
   font-size: 16px;
@@ -78,6 +81,9 @@
 
 /* ── 모바일 (~ 375px) ── */
 @media (max-width: 375px) {
+  .modalContainer {
+    width: 21.5rem;
+  }
   .topBtn {
     display: none;
   }

--- a/src/hooks/useTimer.js
+++ b/src/hooks/useTimer.js
@@ -23,6 +23,14 @@ function useTimer(studyId, durationSec) {
   // 페이지 재진입 시 타이머가 paused 상태인지 여부 (재개 팝업 표시용)
   const [shouldShowResumePopup, setShouldShowResumePopup] = useState(false);
 
+  // 페이지 재진입 시 과거에 진행 중이던 집중 세션 목록
+  const [sessions, setSessions] = useState([]);
+  // 페이지 재진입 시 진행 중이던 집중 세션 목록 모달 상태
+  const [shouldShowSessionList, setShouldShowSessionList] = useState(false);
+
+  // 선택한 세션 정보
+  const [selectedSession, setSelectedSession] = useState(null);
+
   const endTimeRef = useRef(null); // Date.now와 종료 시각을 기준으로 남은 시간 계산
   const intervalIdRef = useRef(null); // 현재 실행 중인 Interval의 ID
   const sessionIdRef = useRef(null);
@@ -66,55 +74,12 @@ function useTimer(studyId, durationSec) {
     const fetchSession = async () => {
       try {
         const res = await getFocusSession(studyId);
-
         const { data } = res.data;
-        if (!data) return;
 
-        sessionIdRef.current = data.id;
-        setEarnedPoint(data.earnedPoint ?? 0);
+        if (!data || data.length === 0) return;
 
-        if (data.status === TIMER_STATUS.RUNNING) {
-          // endTime 기준으로 남은 시간 계산
-          const remaining = Math.ceil(
-            (new Date(data.endTime).getTime() - Date.now()) / 1000,
-          );
-
-          // 타이머가 돌아가는 도중 페이지를 나갔는데, 돌아왔을 때 타이머 시간이 다 지나버린 경우
-          if (remaining <= 0) {
-            handleComplete();
-            return;
-          }
-
-          // 자동 재시작 대신 paused로 전환 후 팝업 표시
-          await updateFocusSession(studyId, data.id, {
-            action: TIMER_STATUS.PAUSED,
-          });
-
-          endTimeRef.current = null;
-          setTimeLeft(remaining);
-          setTimerStatus(TIMER_STATUS.PAUSED);
-          console.log("data.durationSec:", data.durationSec);
-          setSessionDuration(data.durationSec);
-          console.log("sessionDuration 세팅 완료");
-          setShouldShowResumePopup(true);
-        } else if (data.status === TIMER_STATUS.PAUSED) {
-          // paused: endTime - pausedAt 으로 남은 시간 계산
-          const remaining = Math.ceil(
-            (new Date(data.endTime).getTime() -
-              new Date(data.pausedAt).getTime()) /
-              1000,
-          );
-
-          endTimeRef.current = null;
-          setTimeLeft(remaining > 0 ? remaining : 0);
-          setTimerStatus(TIMER_STATUS.PAUSED);
-          console.log("data.durationSec:", data.durationSec);
-          setSessionDuration(data.durationSec);
-          console.log("sessionDuration 세팅 완료");
-
-          // 타이머가 paused 상태안 경우에만 타이머 재개 여부 팝업 표시
-          setShouldShowResumePopup(true);
-        }
+        setSessions(data);
+        setShouldShowSessionList(true);
       } catch (e) {
         showToast("warning", e.userMessage);
       }
@@ -122,6 +87,49 @@ function useTimer(studyId, durationSec) {
 
     fetchSession();
   }, [studyId, handleComplete, showToast]);
+
+  // 세션 선택 시 호출 (SessionListModal에서 클릭 시)
+  const selectSession = async (session) => {
+    // 선택한 세션 저장
+    setSelectedSession(session);
+    sessionIdRef.current = session.id;
+    setEarnedPoint(session.earnedPoint ?? 0);
+
+    if (session.status === TIMER_STATUS.RUNNING) {
+      const remaining = Math.ceil(
+        (new Date(session.endTime).getTime() - Date.now()) / 1000,
+      );
+
+      // 타이머가 돌아가는 도중 페이지를 나갔는데, 돌아왔을 때 타이머 시간이 다 지나버린 경우
+      if (remaining <= 0) {
+        handleComplete();
+        return;
+      }
+
+      // 서버에 paused로 요청
+      await updateFocusSession(studyId, data.id, {
+        action: TIMER_STATUS.PAUSED,
+      });
+
+      endTimeRef.current = null;
+      setTimeLeft(remaining);
+      setTimerStatus(TIMER_STATUS.PAUSED);
+      setSessionDuration(session.durationSec);
+      setShouldShowResumePopup(true);
+    } else if (session.status === TIMER_STATUS.PAUSED) {
+      const remaining = Math.ceil(
+        (new Date(session.endTime).getTime() -
+          new Date(session.pausedAt).getTime()) /
+          1000,
+      );
+
+      endTimeRef.current = null;
+      setTimeLeft(remaining > 0 ? remaining : 0);
+      setTimerStatus(TIMER_STATUS.PAUSED);
+      setSessionDuration(session.durationSec);
+      setShouldShowResumePopup(true);
+    }
+  };
 
   // 타이머 실행
   useEffect(() => {
@@ -156,6 +164,7 @@ function useTimer(studyId, durationSec) {
     try {
       const res = await createFocusSession(studyId, {
         durationSec,
+        // sessionTitle,
       });
 
       const { data } = res.data;
@@ -219,6 +228,10 @@ function useTimer(studyId, durationSec) {
     toast,
     sessionDuration,
     shouldShowResumePopup,
+    sessions,
+    shouldShowSessionList,
+    selectSession,
+    selectedSession,
   };
 }
 

--- a/src/hooks/useTimer.js
+++ b/src/hooks/useTimer.js
@@ -27,9 +27,11 @@ function useTimer(studyId, durationSec) {
   const [sessions, setSessions] = useState([]);
   // 페이지 재진입 시 진행 중이던 집중 세션 목록 모달 상태
   const [shouldShowSessionList, setShouldShowSessionList] = useState(false);
-
   // 선택한 세션 정보
   const [selectedSession, setSelectedSession] = useState(null);
+
+  // 사용자가 설정한 세션 제목
+  const [currentTitle, setCurrentTitle] = useState(null);
 
   const endTimeRef = useRef(null); // Date.now와 종료 시각을 기준으로 남은 시간 계산
   const intervalIdRef = useRef(null); // 현재 실행 중인 Interval의 ID
@@ -94,6 +96,7 @@ function useTimer(studyId, durationSec) {
     setSelectedSession(session);
     sessionIdRef.current = session.id;
     setEarnedPoint(session.earnedPoint ?? 0);
+    setCurrentTitle(session.title); // 세션 선택 시 제목 저장
 
     if (session.status === TIMER_STATUS.RUNNING) {
       const remaining = Math.ceil(
@@ -107,7 +110,7 @@ function useTimer(studyId, durationSec) {
       }
 
       // 서버에 paused로 요청
-      await updateFocusSession(studyId, data.id, {
+      await updateFocusSession(studyId, session.id, {
         action: TIMER_STATUS.PAUSED,
       });
 
@@ -160,11 +163,11 @@ function useTimer(studyId, durationSec) {
     return () => clearInterval(intervalIdRef.current);
   }, [timerStatus, handleComplete]);
 
-  const start = async () => {
+  const start = async (title) => {
     try {
       const res = await createFocusSession(studyId, {
         durationSec,
-        // sessionTitle,
+        title,
       });
 
       const { data } = res.data;
@@ -173,6 +176,7 @@ function useTimer(studyId, durationSec) {
       endTimeRef.current = new Date(data.endTime);
       setTimeLeft(durationSec);
       setTimerStatus(data.status);
+      setCurrentTitle(title); // 시작 시 제목 저장
     } catch (e) {
       showToast("warning", e.userMessage);
     }
@@ -232,6 +236,7 @@ function useTimer(studyId, durationSec) {
     shouldShowSessionList,
     selectSession,
     selectedSession,
+    currentTitle,
   };
 }
 

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -4,8 +4,10 @@ import { getStudyDetail } from "../../api/studies";
 import BoxHeaderInfo from "../../components/BoxHeader/BoxHeaderInfo";
 import NavButton from "../../components/NavButton/NavButton";
 import Toast from "../../components/Toast/Toast";
+import Modal from "../../components/Modal/Modal";
 import ResumeConfirmPopup from "./components/ResumeConfirmPopup";
 import StopConfirmPopup from "./components/StopConfirmPopup";
+import SessionTitleInput from "./components/SessionTitleInput";
 import useTimer, { TIMER_STATUS } from "../../hooks/useTimer";
 import formatTime from "./formatTime";
 import styles from "./Focus.module.css";
@@ -26,6 +28,9 @@ function Focus() {
   const [showResumePopup, setShowResumePopup] = useState(false);
   // 종료 재확인 팝업 상태
   const [showStopConfirmPopup, setShowStopConfirmPopup] = useState(false);
+  // 타이머 시작 시 제목 생성 팝업 상태
+  const [showTitleModal, setShowTitleModal] = useState(false);
+  const [sessionTitle, setSessionTitle] = useState("");
 
   // 직접입력 버튼 클릭 시 분 input 포커스용 ref
   const minInputRef = useRef(null);
@@ -93,6 +98,19 @@ function Focus() {
     setDurationSec(Math.max(1, m * 60 + s));
   };
 
+  // 타이머 start 버튼 클릭 이벤트 핸들러
+  const handleStartClick = () => {
+    if (isEditing) setIsEditing(false);
+    setShowTitleModal(true);
+  };
+
+  // 제목 설정 이후 타이머 시작
+  const handleStart = () => {
+    start(sessionTitle);
+    setShowTitleModal(false);
+    setSessionTitle("");
+  };
+
   // 재진입 팝업에서 "계속 진행" 선택 시 일시정지된 타이머를 재시작하고 팝업 닫기
   const handleResumeConfirm = () => {
     resume();
@@ -115,6 +133,22 @@ function Focus() {
     <section className={styles.container}>
       {toast && (
         <Toast type={toast.type} text={toast.text} point={toast.point} />
+      )}
+
+      {/* 타이머 생성 시 집중 세션 제목 설정 팝업 */}
+      {showTitleModal && (
+        <Modal
+          title="세션 생성"
+          setShowModal={setShowTitleModal}
+          confirmText="생성"
+          innerComponent={
+            <SessionTitleInput
+              value={sessionTitle}
+              onChange={setSessionTitle}
+            />
+          }
+          onClickConfirm={handleStart}
+        />
       )}
 
       {/* 페이지 재진입 시 타이머가 paused 상태일 경우 표시되는 재개 여부 선택 팝업 */}
@@ -237,10 +271,7 @@ function Focus() {
             <button
               type="button"
               className={`${styles.btnBase} ${styles.timerStartButton}`}
-              onClick={() => {
-                if (isEditing) setIsEditing(false);
-                start();
-              }}
+              onClick={handleStartClick}
             >
               <span className="ic play"></span>
               Start!

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -8,6 +8,7 @@ import Modal from "../../components/Modal/Modal";
 import ResumeConfirmPopup from "./components/ResumeConfirmPopup";
 import StopConfirmPopup from "./components/StopConfirmPopup";
 import SessionTitleInput from "./components/SessionTitleInput";
+import SessionListModal from "./components/SessionListModal";
 import useTimer, { TIMER_STATUS } from "../../hooks/useTimer";
 import formatTime from "./formatTime";
 import styles from "./Focus.module.css";
@@ -31,6 +32,20 @@ function Focus() {
   // 타이머 시작 시 제목 생성 팝업 상태
   const [showTitleModal, setShowTitleModal] = useState(false);
   const [sessionTitle, setSessionTitle] = useState("");
+
+  // state 추가
+  const [showSessionListModal, setShowSessionListModal] = useState(true); // 테스트용 true
+  const [sessions, setSessions] = useState([
+    // 테스트용 더미 데이터
+    {
+      id: 1,
+      title: "알고리즘",
+    },
+    {
+      id: 2,
+      title: "리액트 공부",
+    },
+  ]);
 
   // 직접입력 버튼 클릭 시 분 input 포커스용 ref
   const minInputRef = useRef(null);
@@ -135,6 +150,17 @@ function Focus() {
         <Toast type={toast.type} text={toast.text} point={toast.point} />
       )}
 
+      {showSessionListModal && (
+        <SessionListModal
+          sessions={sessions}
+          onSelect={(session) => {
+            console.log("선택된 세션:", session);
+            setShowSessionListModal(false);
+          }}
+          onClose={() => setShowSessionListModal(false)}
+        />
+      )}
+
       {/* 타이머 생성 시 집중 세션 제목 설정 팝업 */}
       {showTitleModal && (
         <Modal
@@ -151,7 +177,7 @@ function Focus() {
         />
       )}
 
-      {/* 페이지 재진입 시 타이머가 paused 상태일 경우 표시되는 재개 여부 선택 팝업 */}
+      {/* 페이지 재진입 시 진행 중이던 타이머가 있었던 경우 표시되는 재개 여부 선택 팝업 */}
       {showResumePopup && (
         <ResumeConfirmPopup
           setShow={setShowResumePopup}

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -33,19 +33,8 @@ function Focus() {
   const [showTitleModal, setShowTitleModal] = useState(false);
   const [sessionTitle, setSessionTitle] = useState("");
 
-  // state 추가
-  const [showSessionListModal, setShowSessionListModal] = useState(true); // 테스트용 true
-  const [sessions, setSessions] = useState([
-    // 테스트용 더미 데이터
-    {
-      id: 1,
-      title: "알고리즘",
-    },
-    {
-      id: 2,
-      title: "리액트 공부",
-    },
-  ]);
+  // 세션 목록 확인 팝업 (테스트용으로 초기값 true로 설정)
+  const [showSessionListModal, setShowSessionListModal] = useState(true);
 
   // 직접입력 버튼 클릭 시 분 input 포커스용 ref
   const minInputRef = useRef(null);
@@ -72,7 +61,35 @@ function Focus() {
     toast,
     sessionDuration,
     shouldShowResumePopup,
+    sessions,
+    shouldShowSessionList,
+    selectSession,
+    selectedSession,
   } = useTimer(studyId, durationSec);
+
+  // 테스트용 더미 데이터
+  const dummySessions = [
+    {
+      id: 1,
+      title: "알고리즘",
+      status: "paused",
+      endTime: new Date(Date.now() + 25 * 60 * 1000).toISOString(),
+      pausedAt: new Date(Date.now()).toISOString(),
+      durationSec: 1500,
+    },
+    {
+      id: 2,
+      title: "리액트 공부",
+      status: "paused",
+      endTime: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+      pausedAt: new Date(Date.now()).toISOString(),
+      durationSec: 600,
+    },
+  ];
+
+  useEffect(() => {
+    if (shouldShowSessionList) setShowSessionListModal(true);
+  }, [shouldShowSessionList]);
 
   // 페이지 재진입 시 타이머 설정 시간 표시
   useEffect(() => {
@@ -152,9 +169,9 @@ function Focus() {
 
       {showSessionListModal && (
         <SessionListModal
-          sessions={sessions}
+          sessions={dummySessions}
           onSelect={(session) => {
-            console.log("선택된 세션:", session);
+            selectSession(session);
             setShowSessionListModal(false);
           }}
           onClose={() => setShowSessionListModal(false)}
@@ -183,6 +200,7 @@ function Focus() {
           setShow={setShowResumePopup}
           onResume={handleResumeConfirm}
           onStop={handleStopClick}
+          title={selectedSession?.title}
         />
       )}
 

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -31,10 +31,10 @@ function Focus() {
   const [showStopConfirmPopup, setShowStopConfirmPopup] = useState(false);
   // 타이머 시작 시 제목 생성 팝업 상태
   const [showTitleModal, setShowTitleModal] = useState(false);
-  const [sessionTitle, setSessionTitle] = useState("");
-
-  // 세션 목록 확인 팝업 (테스트용으로 초기값 true로 설정)
-  const [showSessionListModal, setShowSessionListModal] = useState(true);
+  // 타이머 세션 제목
+  const [title, setTitle] = useState("");
+  // 세션 목록 확인 팝업 상태
+  const [showSessionListModal, setShowSessionListModal] = useState(false);
 
   // 직접입력 버튼 클릭 시 분 input 포커스용 ref
   const minInputRef = useRef(null);
@@ -65,27 +65,8 @@ function Focus() {
     shouldShowSessionList,
     selectSession,
     selectedSession,
+    currentTitle,
   } = useTimer(studyId, durationSec);
-
-  // 테스트용 더미 데이터
-  const dummySessions = [
-    {
-      id: 1,
-      title: "알고리즘",
-      status: "paused",
-      endTime: new Date(Date.now() + 25 * 60 * 1000).toISOString(),
-      pausedAt: new Date(Date.now()).toISOString(),
-      durationSec: 1500,
-    },
-    {
-      id: 2,
-      title: "리액트 공부",
-      status: "paused",
-      endTime: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
-      pausedAt: new Date(Date.now()).toISOString(),
-      durationSec: 600,
-    },
-  ];
 
   useEffect(() => {
     if (shouldShowSessionList) setShowSessionListModal(true);
@@ -138,10 +119,10 @@ function Focus() {
 
   // 제목 설정 이후 타이머 시작
   const handleStart = () => {
-    if (!sessionTitle.trim()) return;
-    start(sessionTitle);
+    if (!title.trim()) return;
+    start(title);
     setShowTitleModal(false);
-    setSessionTitle("");
+    setTitle("");
   };
 
   // 재진입 팝업에서 "계속 진행" 선택 시 일시정지된 타이머를 재시작하고 팝업 닫기
@@ -170,7 +151,7 @@ function Focus() {
 
       {showSessionListModal && (
         <SessionListModal
-          sessions={dummySessions}
+          sessions={sessions}
           onSelect={(session) => {
             selectSession(session);
             setShowSessionListModal(false);
@@ -186,10 +167,7 @@ function Focus() {
           setShowModal={setShowTitleModal}
           confirmText="생성"
           innerComponent={
-            <SessionTitleInput
-              value={sessionTitle}
-              onChange={setSessionTitle}
-            />
+            <SessionTitleInput value={title} onChange={setTitle} />
           }
           onClickConfirm={handleStart}
         />
@@ -237,7 +215,11 @@ function Focus() {
       {/* 타이머 */}
       <div className={styles.timerSection}>
         <div className={styles.timerSectionheader}>
-          <h3 className={styles.timerTitle}>오늘의 집중</h3>
+          <h3 className={styles.timerTitle}>
+            {isRunning || isPaused
+              ? (currentTitle ?? "오늘의 집중")
+              : "오늘의 집중"}
+          </h3>
 
           {/* 타이머 시작 전/완료: 집중 시간 설정 UI 표시 */}
           {isIdle || isCompleted ? (

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -138,6 +138,7 @@ function Focus() {
 
   // 제목 설정 이후 타이머 시작
   const handleStart = () => {
+    if (!sessionTitle.trim()) return;
     start(sessionTitle);
     setShowTitleModal(false);
     setSessionTitle("");

--- a/src/pages/FocusPage/components/ResumeConfirmPopup.jsx
+++ b/src/pages/FocusPage/components/ResumeConfirmPopup.jsx
@@ -1,10 +1,14 @@
 import React from "react";
 import Popup from "../../../components/Popup/Popup";
 
-function ResumeConfirmPopup({ setShow, onResume, onStop }) {
+function ResumeConfirmPopup({ setShow, onResume, onStop, title }) {
   return (
     <Popup
-      message="이전에 진행 중이던 집중이 있습니다. 계속 진행하시겠습니까?"
+      message={
+        title
+          ? `이전에 진행 중이던 "${title}"을 계속 진행하시겠습니까?`
+          : "이전에 진행 중이던 집중이 있습니다. 계속 진행하시겠습니까?"
+      }
       hasCancel
       setShowPopup={setShow}
       onClickConfirm={onResume}

--- a/src/pages/FocusPage/components/SessionListModal.jsx
+++ b/src/pages/FocusPage/components/SessionListModal.jsx
@@ -1,0 +1,44 @@
+import Modal from "../../../components/Modal/Modal";
+import styles from "./SessionListModal.module.css";
+
+function SessionListModal({ sessions, onSelect, onClose }) {
+  const inner = (
+    <div className={styles.container}>
+      <p className={styles.description}>
+        이 스터디에 진행 중이던 집중 세션이 있어요.
+        <br />
+        이어서 진행하고 싶은 세션을 선택하거나,
+        <br />
+        닫기를 눌러 새로 시작하세요.
+      </p>
+      <div className={styles.list}>
+        {sessions.map((session) => {
+          return (
+            <button
+              key={session.id}
+              className={styles.item}
+              onClick={() => onSelect(session)}
+            >
+              <span className={styles.title}>
+                {session.title ?? "오늘의 집중"}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+
+  return (
+    <Modal
+      title="진행 중인 집중 세션"
+      hasCancel={false}
+      confirmText="닫기"
+      setShowModal={onClose}
+      onClickConfirm={onClose}
+      innerComponent={inner}
+    />
+  );
+}
+
+export default SessionListModal;

--- a/src/pages/FocusPage/components/SessionListModal.jsx
+++ b/src/pages/FocusPage/components/SessionListModal.jsx
@@ -7,9 +7,7 @@ function SessionListModal({ sessions, onSelect, onClose }) {
       <p className={styles.description}>
         이 스터디에 진행 중이던 집중 세션이 있어요.
         <br />
-        이어서 진행하고 싶은 세션을 선택하거나,
-        <br />
-        닫기를 눌러 새로 시작하세요.
+        이어서 진행하고 싶은 세션을 선택하거나, 닫기를 눌러 새로 시작하세요.
       </p>
       <div className={styles.list}>
         {sessions.map((session) => {

--- a/src/pages/FocusPage/components/SessionListModal.module.css
+++ b/src/pages/FocusPage/components/SessionListModal.module.css
@@ -7,6 +7,7 @@
 }
 
 .description {
+  margin-bottom: 1rem;
   text-align: center;
   font: var(--text-18-medium);
   color: var(--black);

--- a/src/pages/FocusPage/components/SessionListModal.module.css
+++ b/src/pages/FocusPage/components/SessionListModal.module.css
@@ -1,0 +1,39 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  min-width: 24rem;
+  padding: 0.5rem 0;
+}
+
+.description {
+  text-align: center;
+  font: var(--text-18-medium);
+  color: var(--black);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.item {
+  width: 100%;
+  height: 4rem;
+  padding: 0 1.5rem;
+  border-radius: 1.25rem;
+  background-color: var(--gray-200);
+  color: var(--gray-500);
+  font: var(--text-16-bold);
+  text-align: center;
+  cursor: pointer;
+  transition:
+    opacity 0.15s ease,
+    background-color 0.2s ease;
+}
+
+.item:hover {
+  background: var(--brand);
+  color: var(--white);
+}

--- a/src/pages/FocusPage/components/SessionTitleInput.jsx
+++ b/src/pages/FocusPage/components/SessionTitleInput.jsx
@@ -1,6 +1,8 @@
 import styles from "./SessionTitleInput.module.css";
 
 function SessionTitleInput({ value, onChange }) {
+  const isInvalid = value.length > 0 && value.trim().length === 0;
+
   return (
     <div className={styles.inputElement}>
       <label htmlFor="session-title" className={styles.label}>
@@ -14,8 +16,10 @@ function SessionTitleInput({ value, onChange }) {
         onChange={(e) => onChange(e.target.value)}
         placeholder="집중 세션 제목을 입력하세요"
       />
-      <div className={styles.helperText}>
-        세션 제목은 생성 후 수정할 수 없습니다.
+      <div className={isInvalid ? styles.errorText : styles.helperText}>
+        {isInvalid
+          ? "제목을 입력해주세요."
+          : "세션 제목은 생성 후 수정할 수 없습니다."}
       </div>
     </div>
   );

--- a/src/pages/FocusPage/components/SessionTitleInput.jsx
+++ b/src/pages/FocusPage/components/SessionTitleInput.jsx
@@ -1,0 +1,24 @@
+import styles from "./SessionTitleInput.module.css";
+
+function SessionTitleInput({ value, onChange }) {
+  return (
+    <div className={styles.inputElement}>
+      <label htmlFor="session-title" className={styles.label}>
+        집중 세션 제목
+      </label>
+      <input
+        type="text"
+        id="session-title"
+        className={styles.input}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="집중 세션 제목을 입력하세요"
+      />
+      <div className={styles.helperText}>
+        세션 제목은 생성 후 수정할 수 없습니다.
+      </div>
+    </div>
+  );
+}
+
+export default SessionTitleInput;

--- a/src/pages/FocusPage/components/SessionTitleInput.module.css
+++ b/src/pages/FocusPage/components/SessionTitleInput.module.css
@@ -3,7 +3,6 @@
   flex-direction: column;
   align-items: flex-start;
   width: 100%;
-  padding: 0.5rem;
 }
 
 .label {

--- a/src/pages/FocusPage/components/SessionTitleInput.module.css
+++ b/src/pages/FocusPage/components/SessionTitleInput.module.css
@@ -28,3 +28,7 @@
   color: var(--gray-500);
   padding: 0.5rem 0 0 0.3rem;
 }
+
+.errorText {
+  border-color: var(--error);
+}

--- a/src/pages/FocusPage/components/SessionTitleInput.module.css
+++ b/src/pages/FocusPage/components/SessionTitleInput.module.css
@@ -1,0 +1,31 @@
+.inputElement {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+  padding: 0.5rem;
+}
+
+.label {
+  font: var(--text-16-medium);
+  color: var(--black);
+}
+
+.input {
+  width: 100%;
+  margin-top: 0.75rem;
+  padding: 0.9375rem 1.25rem;
+  border-radius: 0.9375rem;
+  border: 1px solid var(--gray-300);
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--brand);
+}
+
+.helperText {
+  font: var(--text-12-regular);
+  color: var(--gray-500);
+  padding: 0.5rem 0 0 0.3rem;
+}


### PR DESCRIPTION
## 개요
스터디별 세션을 1개로 제한하고 있어 여러 스터디원이 동시에 집중 타이머를 사용할 수 없는 문제가 있었습니다.
따라서 세션 생성 시 제목을 입력받아 각 세션을 식별할 수 있도록 했습니다. 또한 페이지 재진입 시 진행 중인 세션 목록을 표시해 원하는 세션을 선택하거나, 혹은 새로운 세션을 생성할 수 있도록 변경했습니다.


## 변경 사항
- 세션 생성 시 title 입력 팝업 추가 (최소 1자 이상 유효성 검증 포함)
- 페이지 재진입 시 진행 중인 세션 목록 모달 표시
- 세션 클릭 시 해당 세션 복원 및 재개 여부 팝업 표시
- 타이머 진행 중 세션 제목이 "오늘의 집중" 대신 표시되도록 변경
- 세션 목록 조회 및 생성 API 연동
- 재개 여부 팝업에 선택한 세션 제목 표시

## 스크린샷 (UI 변경 시)
### 집중 세션 생성 시 제목 설정
<img width="1469" height="952" alt="localhost_5173_studies_22_focus (3)" src="https://github.com/user-attachments/assets/da46fdc2-a6b0-48fd-b5ba-77e64482e4d0" />

### 집중 세션 실행: 사용자가 설정한 제목이 표시됨
<img width="1469" height="952" alt="localhost_5173_studies_22_focus (4)" src="https://github.com/user-attachments/assets/cc270b7b-9eb7-4c70-b87f-52de486faa36" />

### 페이지 재진입 시 이전에 진행 중이던 세션 목록 표시
<img width="1469" height="952" alt="localhost_5173_studies_22_focus (5)" src="https://github.com/user-attachments/assets/ee2a9deb-3b0d-4aee-b64b-af1fe555f299" />

### 세션 목록에서 세션 클릭 시 
<img width="1469" height="952" alt="localhost_5173_studies_22_focus (6)" src="https://github.com/user-attachments/assets/0a657fc2-203e-4da8-a473-a68105c75201" />

### 계속 진행 버튼 클릭 시 타이머가 진행됨
<img width="1469" height="952" alt="localhost_5173_studies_22_focus (7)" src="https://github.com/user-attachments/assets/148038c4-5790-416a-9323-d52051d190be" />


## 영향 범위
- `Focus.jsx`, `useTimer.js` 수정
- `SessionListModal`, `SessionTitleInput` 컴포넌트 추가
- 공통 컴포넌트인 Modal 수정: 반응형으로 너비가 변하도록 변경 

## 관련 이슈
- close #45
