### PR TITLE
fix: 스터디 상세 페이지 - 비밀번호 모달 입력 시 (다른 페이지 이동 시) 토스트 메세지 뜨도록 함.

### DIFF
--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -18,6 +18,7 @@ const Modal = ({
   innerComponent,
   onClickConfirm,
   onClickCancel,
+  preventAutoClose = false,
 }) => {
   return (
     <div className={styles.overlay}>
@@ -55,8 +56,8 @@ const Modal = ({
               variant="create"
               label={confirmText}
               onClick={async () => {
-                const isClose = await (onClickConfirm && onClickConfirm()); //모달을 닫지 말아야 하는 상황이라면, onClickConfirm함수에서 false를 리턴하도록 하자.
-                if (isClose !== false) {
+                await (onClickConfirm && onClickConfirm()); //모달을 닫지 말아야 하는 상황이라면, onClickConfirm함수에서 false를 리턴하도록 하자.
+                if (!preventAutoClose) {
                   setShowModal(false);
                 }
               }}

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -55,8 +55,10 @@ const Modal = ({
               variant="create"
               label={confirmText}
               onClick={async () => {
-                await (onClickConfirm && onClickConfirm());
-                setShowModal(false);
+                const isClose = await (onClickConfirm && onClickConfirm()); //모달을 닫지 말아야 하는 상황이라면, onClickConfirm함수에서 false를 리턴하도록 하자.
+                if (isClose !== false) {
+                  setShowModal(false);
+                }
               }}
             />
           </div>

--- a/src/pages/StudyDetailPage/StudyDetail.jsx
+++ b/src/pages/StudyDetailPage/StudyDetail.jsx
@@ -115,22 +115,33 @@ const StudyDetail = () => {
   };
 
   //비밀번호 인증 성공 시 실행할 함수.
+  //ㄴ그렇담 여기에서 성공 토스트 메세지를 실행한다!
   const onPasswordSuccess = () => {
     switch (pwType) {
       case "modify":
-        navigate(`/studies/new`, {
-          state: { type: "modify", study },
-        });
+        showToast("success", "인증 되었습니다!"); //비밀번호 일치로 넘어갈 때도, 세션에 들어있어서 넘어갈 때도 모두 토스트 메세지를 보여줄 수 있다.
+        setTimeout(() => {
+          //성공 시의 toast메세지가 보이게 하기 위함.
+          navigate(`/studies/new`, { state: { type: "modify", study } });
+        }, 500); // 0.5초 후 이동
         break;
       case "delete":
         //진짜로 삭제할거냔 거 표시하기 -> 취소버튼 누르면, 원래 상세 페이지로. 확인 버튼 누르면 -> delete api 호출
         setShowDeletePopup(true);
         break;
       case "habit":
-        navigate(`/studies/${studyId}/habits`);
+        showToast("success", "인증 되었습니다!");
+        setTimeout(() => {
+          navigate(`/studies/${studyId}/habits`);
+        }, 500);
+
         break;
       case "focus":
-        navigate(`/studies/${studyId}/focus`);
+        showToast("success", "인증 되었습니다!");
+        setTimeout(() => {
+          navigate(`/studies/${studyId}/focus`);
+        }, 500);
+
         break;
       default:
         break;

--- a/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.jsx
+++ b/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.jsx
@@ -53,17 +53,17 @@ const PasswordModal = ({
   const onClickConfirmHandler = async () => {
     if (!password.trim()) {
       showToast("warning", "비밀번호를 입력해주세요!");
-      return false;
+      return;
     }
     try {
       const res = await verifyPassword(studyId, { password });
       console.log("비밀번호 검증 결과=>", res);
       // showToast("success", "인증 되었습니다!");
-      //setShowModal(false); //비밀번호 일치하면 여기서 모달 닫음. (Modal에선 나가기 버튼 누를 시 모달 닫음)
+      setShowModal(false); //비밀번호 일치하면 여기서 모달 닫음.
       onPasswordSuccess();
     } catch (e) {
       showToast("warning", "비밀번호가 일치하지 않습니다!");
-      return false;
+      return;
     }
   };
   return (
@@ -76,6 +76,7 @@ const PasswordModal = ({
         confirmText={confirmText}
         innerComponent={innerComponent}
         onClickConfirm={onClickConfirmHandler}
+        preventAutoClose={true}
       ></Modal>
       <div className={styles.toast}>
         {toast && <Toast type={toast.type} text={toast.text} />}

--- a/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.jsx
+++ b/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.jsx
@@ -53,16 +53,17 @@ const PasswordModal = ({
   const onClickConfirmHandler = async () => {
     if (!password.trim()) {
       showToast("warning", "비밀번호를 입력해주세요!");
-      return;
+      return false;
     }
     try {
       const res = await verifyPassword(studyId, { password });
       console.log("비밀번호 검증 결과=>", res);
-      showToast("success", "인증 되었습니다!");
-      setShowModal(false); //비밀번호 일치하면 여기서 모달 닫음. (Modal에선 나가기 버튼 누를 시 모달 닫음)
+      // showToast("success", "인증 되었습니다!");
+      //setShowModal(false); //비밀번호 일치하면 여기서 모달 닫음. (Modal에선 나가기 버튼 누를 시 모달 닫음)
       onPasswordSuccess();
     } catch (e) {
       showToast("warning", "비밀번호가 일치하지 않습니다!");
+      return false;
     }
   };
   return (


### PR DESCRIPTION
## 개요

토스트 메세지가 제대로 뜨지 않던 오류를 해결하였습니다.

비밀번호 미입력/미일치 시 토스트 메세지를 뜨게 하였습니다.
비밀번호 일치 시 토스트 메세지를 뜨게했습니다.
이미 세션에 있는 스터디의 경우, 수정/삭제/습관접근/집중접근 시 토스트 메세지를 뜨게 하고 넘어가도록 했습니다.

## 변경 사항

- `PasswordModal.jsx` : 비밀번호 모달이 자동으로 닫히게 하지 않기 위해, `Modal`컴포넌트에 `preventAutoClose={ture}`를 props로 전달함.
- `Modal.jsx` : `preventAutoClose` Props를 추가하여, 이 값이 true일 시, 모달이 자동으로 닫히게 하는 코드를 실행하지 않음.
- `StudyDetail.jsx` : `navigate`코드를 `setTimeout`코드로 감싸서, 0.5초 뒤에 실행되도록 함. 이를 통해 success 토스트가 보일 수 있게 됨.

## 스크린샷 (UI 변경 시)

(success 토스트가 나타나는게 순식간이라 캡쳐를 못하겠음)

## 영향 범위

`Modal` 공통 컴포넌트에 코드 추가함.

## 관련 이슈

- close #51 
