### PR TITLE
fix: 집중 세션 제목 미입력 시 유효성 검사 미동작 수정

### DIFF
--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -35,11 +35,13 @@ function Focus() {
   const [title, setTitle] = useState("");
   // 세션 목록 확인 팝업 상태
   const [showSessionListModal, setShowSessionListModal] = useState(false);
+  // 세션 제목 입력 시 에러
+  const [titleError, setTitleError] = useState("");
 
   // 직접입력 버튼 클릭 시 분 input 포커스용 ref
   const minInputRef = useRef(null);
 
-  // 스터디 정보 조회 (추후 전역 상태로 수정 예정)
+  // 스터디 정보 조회
   useEffect(() => {
     const fetchStudy = async () => {
       const res = await getStudyDetail(studyId);
@@ -118,11 +120,16 @@ function Focus() {
   };
 
   // 제목 설정 이후 타이머 시작
-  const handleStart = () => {
-    if (!title.trim()) return;
+  const handleStart = async () => {
+    if (!title.trim()) {
+      setTitleError("제목을 입력해주세요.");
+      return;
+    }
+
     start(title);
     setShowTitleModal(false);
     setTitle("");
+    setTitleError("");
   };
 
   // 재진입 팝업에서 "계속 진행" 선택 시 일시정지된 타이머를 재시작하고 팝업 닫기
@@ -167,9 +174,17 @@ function Focus() {
           setShowModal={setShowTitleModal}
           confirmText="생성"
           innerComponent={
-            <SessionTitleInput value={title} onChange={setTitle} />
+            <SessionTitleInput
+              value={title}
+              onChange={(val) => {
+                setTitle(val);
+                if (val.trim()) setTitleError("");
+              }}
+              errorMessage={titleError}
+            />
           }
           onClickConfirm={handleStart}
+          preventAutoClose={true}
         />
       )}
 

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -116,6 +116,8 @@ function Focus() {
   // 타이머 start 버튼 클릭 이벤트 핸들러
   const handleStartClick = () => {
     if (isEditing) setIsEditing(false);
+    setTitle("");
+    setTitleError("");
     setShowTitleModal(true);
   };
 

--- a/src/pages/FocusPage/components/SessionTitleInput.jsx
+++ b/src/pages/FocusPage/components/SessionTitleInput.jsx
@@ -1,7 +1,7 @@
 import styles from "./SessionTitleInput.module.css";
 
-function SessionTitleInput({ value, onChange }) {
-  const isInvalid = value.length > 0 && value.trim().length === 0;
+function SessionTitleInput({ value, onChange, errorMessage }) {
+  const isInvalid = !!errorMessage || (value.length > 0 && !value.trim());
 
   return (
     <div className={styles.inputElement}>
@@ -11,14 +11,14 @@ function SessionTitleInput({ value, onChange }) {
       <input
         type="text"
         id="session-title"
-        className={styles.input}
+        className={`${styles.input} ${isInvalid ? styles.inputError : ""}`}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder="집중 세션 제목을 입력하세요"
       />
-      <div className={isInvalid ? styles.errorText : styles.helperText}>
+      <div className={`${styles.helperText} ${isInvalid ? styles.error : ""}`}>
         {isInvalid
-          ? "제목을 입력해주세요."
+          ? errorMessage || "제목을 입력해주세요."
           : "세션 제목은 생성 후 수정할 수 없습니다."}
       </div>
     </div>

--- a/src/pages/FocusPage/components/SessionTitleInput.module.css
+++ b/src/pages/FocusPage/components/SessionTitleInput.module.css
@@ -23,12 +23,17 @@
   border-color: var(--brand);
 }
 
+.inputError,
+.inputError:focus {
+  border-color: var(--error);
+}
+
 .helperText {
-  font: var(--text-12-regular);
+  font: var(--text-14-regular);
   color: var(--gray-500);
   padding: 0.5rem 0 0 0.3rem;
 }
 
-.errorText {
-  border-color: var(--error);
+.error {
+  color: var(--error);
 }


### PR DESCRIPTION
## 개요
세션 생성 모달에서 제목을 입력하지 않고 생성 버튼을 눌러도 에러 메세지가 표시되지 않고 모달이 닫히는 문제를 수정했습니다.
추가로 모달을 닫고 다시 열었을 때 이전 에러 상태가 유지되는 문제도 같이 수정했습니다.

## 변경 사항
- `SessionTitleInput`의 `isInvalid` 조건에 `errorMessage` 반영
- `Focus`에 `titleError` 상태 추가 및 제목 미입력 시 에러 설정, 입력 시 초기화 로직 추가
- `Focus`의 `handleStartClick`에서 모달 재오픈 시 `title`, `titleError` 초기화

## 스크린샷 (UI 변경 시)
### 세션 생성 모달에서 제목 미입력 후 생성 버튼 클릭
<img width="1978" height="1624" alt="localhost_5173_studies_26_focus (2)" src="https://github.com/user-attachments/assets/422c49fc-8a88-4d66-ad6c-1a6562478069" />

- input의 border의 색상 변경 및 에러 메시지 표시

## 영향 범위
- `SessionTitleInput.js` 및 `Focus.js` 수정
- 다른 기능 영향 없음

## 관련 이슈
- close #57
