### PR TITLE
refactor: 스터디 생성 후 상세 페이지로 이동

### DIFF
--- a/src/pages/StudyFormPage/StudyForm.jsx
+++ b/src/pages/StudyFormPage/StudyForm.jsx
@@ -174,7 +174,8 @@ function StudyForm({ type = "create", study = {} }) {
         console.log("type이 잘못되었습니다. type=>", type);
     }
     showToast("success", "등록되었습니다!");
-    navigate(`/studies/${study.id}`); //create,modify모두 스터디 상세 페이지로 이동하도록 한다.
+    console.log("이 id의 상세 페이지로 이동 =>", result.data.data.id);
+    navigate(`/studies/${result.data.data.id}`); //create,modify모두 스터디 상세 페이지로 이동하도록 한다.
     //데이터가 등록된 후에 이동해야 하기에, Link가 아닌 navigate를 이용.
   };
   return (

--- a/src/pages/StudyFormPage/StudyForm.jsx
+++ b/src/pages/StudyFormPage/StudyForm.jsx
@@ -174,15 +174,8 @@ function StudyForm({ type = "create", study = {} }) {
         console.log("type이 잘못되었습니다. type=>", type);
     }
     showToast("success", "등록되었습니다!");
-    switch (type) {
-      case "create": //홈으로 (생성 버튼 있는 곳)
-        navigate("/"); //데이터가 등록된 후에 이동해야 하기에, Link가 아닌 navigate를 이용.
-        break;
-      case "modify": //스터디 상세 페이지로 (수정 버튼 있는 곳)
-        navigate(`/studies/${study.id}`);
-        break;
-      default: //무조건 홈으로
-    }
+    navigate(`/studies/${study.id}`); //create,modify모두 스터디 상세 페이지로 이동하도록 한다.
+    //데이터가 등록된 후에 이동해야 하기에, Link가 아닌 navigate를 이용.
   };
   return (
     <div className={styles.container}>


### PR DESCRIPTION
## 개요

사용자 경험 향상을 위해, 스터디 생성 후 상세 페이지로 이동되게 하여 [스터디 생성 → 습관 생성] 시의 depth를 줄임.

## 변경 사항

- `StufyForm.jsx` : 기존에 생성과 수정을 구분하여 navigate하던 switch문을 없애고, 모두 상세페이지로 navigate되도록 함.



## 관련 이슈

- close #63 
