### PR TITLE
fix: 스터디 상세 - 비밀번호 모듈 오작동 해결

### DIFF
--- a/src/pages/StudyDetailPage/StudyDetail.jsx
+++ b/src/pages/StudyDetailPage/StudyDetail.jsx
@@ -101,8 +101,8 @@ const StudyDetail = () => {
   };
 
   //세션을 체크하고, 그에 따른 결과를 이어지는 함수.
-  const validateSessionAndProceed = (type) => {
-    const isInSession = handleCheckSession();
+  const validateSessionAndProceed = async (type) => {
+    const isInSession = await handleCheckSession();
     if (isInSession) {
       onPasswordSuccess(type);
     } else {

--- a/src/pages/StudyDetailPage/StudyDetail.jsx
+++ b/src/pages/StudyDetailPage/StudyDetail.jsx
@@ -69,6 +69,8 @@ const StudyDetail = () => {
 
   const [confirmText, setConfirmText] = useState(""); //버튼마다 비밀번호 모달 내 버튼명이 다르므로, 여기에 저장해서 사용.
 
+  const [currentType, setCurrentType] = useState("");
+
   //토스트
   const { toast, showToast } = useToast();
 
@@ -102,10 +104,11 @@ const StudyDetail = () => {
 
   //세션을 체크하고, 그에 따른 결과를 이어지는 함수.
   const validateSessionAndProceed = async (type) => {
-    const isInSession = await handleCheckSession();
+    const isInSession = await handleCheckSession(); //await을 해야 정상적인 순서로 작동됨.
     if (isInSession) {
       onPasswordSuccess(type);
     } else {
+      setCurrentType(type); // type을 state로 저장
       setShowPwModal(true);
     }
   };
@@ -195,7 +198,7 @@ const StudyDetail = () => {
                 studyId={study?.id}
                 title={study?.title}
                 confirmText={confirmText}
-                onPasswordSuccess={onPasswordSuccess}
+                onPasswordSuccess={() => onPasswordSuccess(currentType)}
               />
             )}
           {showDeletePopup && ( //정말 삭제하시겠습니까? 팝업

--- a/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.jsx
+++ b/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.jsx
@@ -58,7 +58,6 @@ const PasswordModal = ({
     try {
       const res = await verifyPassword(studyId, { password });
       console.log("비밀번호 검증 결과=>", res);
-      // showToast("success", "인증 되었습니다!");
       setShowModal(false); //비밀번호 일치하면 여기서 모달 닫음.
       onPasswordSuccess();
     } catch (e) {


### PR DESCRIPTION
## 개요

1. 버튼 클릭 시 비밀번호 모듈이 뜨지 않고 바로 페이지가 이동되는 문제 해결
2. 비밀번호 일치 시, 페이지가 이동하지 않는 문제 해결


## 변경 사항

- 비밀번호 모듈이 뜨지 않는 문제 : `handleCheckSession`함수에서 Promise를 반환했는데, 이를 성공으로 인식하고 페이지를 이동시킴. → `await`, `async`를 추가하여 정상적으로 데이터를 받아올 수 있도록 함.
- 비밀번호 일치 시, 페이지가 이동하지 않는 문제 : `PasswordModal`에서 `onPassowrdSuccess`를 부를 때, `type`인수를 주지 않았던 문제. (이전에 type을 상태에서 일반 변수로 변경한 것이, 여기엔 적용되지 않은 것) → 선택된 상태를 저장하는 `currentType`을 만듦. onPasswordSuccess Props에 currentType을 인수로 넣은 함수를 전달함.


## 관련 이슈

- close #66 
