### PR TITLE
fix: 습관 모달에서 여러 항목 동시 수정 시 마지막 항목만 반영되는 문제 해결

### DIFF
--- a/src/hooks/useHabits.js
+++ b/src/hooks/useHabits.js
@@ -18,6 +18,7 @@ function useHabits(studyId) {
     setError(null);
     try {
       const res = await getTodayHabits(studyId);
+      console.log("[useHabits] getTodayHabits 응답:", res.data);
       setHabits(res.data.data);
     } catch (err) {
       setError(err.userMessage || "습관을 불러오지 못했습니다.");

--- a/src/pages/HabitPage/Habit.jsx
+++ b/src/pages/HabitPage/Habit.jsx
@@ -19,6 +19,7 @@ function Habit() {
   const [editingHabitId, setEditingHabitId] = useState(null);
   const [originalHabitName, setOriginalHabitName] = useState("");
   const [editingValue, setEditingValue] = useState("");
+  const [stagedEdits, setStagedEdits] = useState({});
   const { habits, isLoading, toggleHabit, addHabit, editHabit, removeHabit } =
     useHabits(studyId);
 
@@ -42,20 +43,25 @@ function Habit() {
       return;
     }
     setEditingHabitId(habit.id);
-    setEditingValue(habit.habitName);
+    // 이미 stagedEdits에 수정값이 있으면 그걸 보여줌 (다른 습관 편집 후 돌아올 때)
+    setEditingValue(stagedEdits[habit.id] ?? habit.habitName);
     setOriginalHabitName(habit.habitName);
   };
 
-  // 수정 완료: 편집 중인 습관 저장 + 추가 중인 습관 저장
+  // 편집값 변경 시 stagedEdits에 누적
+  const handleEditChange = (habitId, value) => {
+    setEditingValue(value);
+    setStagedEdits((prev) => ({ ...prev, [habitId]: value }));
+  };
+
+  // 수정 완료: stagedEdits 전체 API 전송 + 추가 중인 습관 저장
   const handleConfirm = async () => {
     try {
-      if (
-        editingHabitId !== null &&
-        editingValue.trim() &&
-        editingValue.trim() !== originalHabitName
-      ) {
-        await editHabit(editingHabitId, editingValue.trim());
-      }
+      const editPromises = Object.entries(stagedEdits)
+        .filter(([, name]) => name.trim())
+        .map(([id, name]) => editHabit(Number(id), name.trim()));
+      await Promise.all(editPromises);
+
       if (isAdding && habitInput.trim()) {
         await addHabit(habitInput);
       }
@@ -65,6 +71,7 @@ function Habit() {
       setOriginalHabitName("");
       setHabitInput("");
       setIsAdding(false);
+      setStagedEdits({});
     }
   };
 
@@ -107,8 +114,9 @@ function Habit() {
           isEditMode={true}
           isEditing={editingHabitId === habit.id}
           editValue={editingValue}
+          stagedName={stagedEdits[habit.id]}
           onEditStart={handleEditStart}
-          onEditChange={setEditingValue}
+          onEditChange={handleEditChange}
           onDelete={handleDelete}
         />
       ))}
@@ -214,6 +222,7 @@ function Habit() {
             setEditingValue("");
             setIsAdding(false);
             setHabitInput("");
+            setStagedEdits({});
           }}
           innerComponent={modalInner}
         />

--- a/src/pages/HabitPage/components/HabitItem.jsx
+++ b/src/pages/HabitPage/components/HabitItem.jsx
@@ -6,6 +6,7 @@ function HabitItem({
   isEditMode,
   isEditing,
   editValue,
+  stagedName,
   onToggle,
   onEditStart,
   onEditChange,
@@ -20,7 +21,7 @@ function HabitItem({
             <input
               className={styles.editInput}
               value={editValue}
-              onChange={(e) => onEditChange(e.target.value)}
+              onChange={(e) => onEditChange(habit.id, e.target.value)}
               onKeyDown={(e) => {
                 if (e.key === "Escape") onEditStart(null);
               }}
@@ -45,7 +46,7 @@ function HabitItem({
           className={`${styles.editItem} ${habit.isCompleted ? styles.completed : ""}`}
           onClick={() => onEditStart(habit)}
         >
-          <span className={styles.editName}>{habit.habitName}</span>
+          <span className={styles.editName}>{stagedName ?? habit.habitName}</span>
         </button>
         <button
           className={styles.deleteBtn}


### PR DESCRIPTION
## 개요

습관 모달에서 여러 항목의 습관 수정 시 마지막 항목만 반영되는 이슈 해결

## 변경 사항

- `stagedEdits` 상태 추가 — 수정 완료 전까지 모든 편집 변경사항을 `{ habitId: name }` 형태로 누적
- `handleEditChange` 함수 추가 — 편집값이 바뀔 때마다 `stagedEdits`에 기록
- `handleConfirm` 수정 — 기존 단일 `editHabit` 호출 대신 `stagedEdits` 전체를 `Promise.all`로 병렬 API 전송
- `handleEditStart` 수정 — 이미 편집한 습관으로 돌아올 때 `stagedEdits`의 값을 인풋에 복원
- `HabitItem`에 `stagedName` prop 추가 — 편집 모드가 아닐 때도 staged된 이름을 화면에 표시

- close #69 
