### PR TITLE
refactor: useTimer 훅 관심사 분리

### DIFF
--- a/src/hooks/timer/timerConstants.js
+++ b/src/hooks/timer/timerConstants.js
@@ -1,0 +1,7 @@
+export const TIMER_STATUS = {
+  IDLE: "idle",
+  RUNNING: "running",
+  PAUSED: "paused",
+  COMPLETED: "completed",
+  FAILED: "failed",
+};

--- a/src/hooks/timer/timerUtils.js
+++ b/src/hooks/timer/timerUtils.js
@@ -1,0 +1,6 @@
+export const calcRemaining = (endTime, pausedAt = null) =>
+  Math.ceil(
+    (new Date(endTime).getTime() -
+      (pausedAt ? new Date(pausedAt).getTime() : Date.now())) /
+      1000,
+  );

--- a/src/hooks/timer/useFocusSession.js
+++ b/src/hooks/timer/useFocusSession.js
@@ -1,0 +1,51 @@
+import { useEffect, useState, useCallback } from "react";
+import {
+  getFocusSession,
+  createFocusSession,
+  updateFocusSession,
+} from "../../api/focus";
+
+function useFocusSession(studyId) {
+  const [sessions, setSessions] = useState([]);
+  const [shouldShowSessionList, setShouldShowSessionList] = useState(false);
+
+  useEffect(() => {
+    const fetchSession = async () => {
+      try {
+        const res = await getFocusSession(studyId);
+        const { data } = res.data;
+        if (!data || data.length === 0) return;
+        setSessions(data);
+        setShouldShowSessionList(true);
+      } catch (e) {
+        throw e;
+      }
+    };
+    fetchSession();
+  }, [studyId]);
+
+  const createSession = useCallback(
+    async ({ durationSec, title }) => {
+      const res = await createFocusSession(studyId, { durationSec, title });
+      return res.data.data;
+    },
+    [studyId],
+  );
+
+  const updateSession = useCallback(
+    async (sessionId, action) => {
+      const res = await updateFocusSession(studyId, sessionId, { action });
+      return res.data.data;
+    },
+    [studyId],
+  );
+
+  return {
+    sessions,
+    shouldShowSessionList,
+    createSession,
+    updateSession,
+  };
+}
+
+export default useFocusSession;

--- a/src/hooks/timer/useTimer.js
+++ b/src/hooks/timer/useTimer.js
@@ -3,17 +3,10 @@ import {
   getFocusSession,
   createFocusSession,
   updateFocusSession,
-} from "../api/focus";
-import useToast from "./useToast";
+} from "../../api/focus";
+import useToast from "../useToast";
 import useTimerInterval from "./useTimerInterval";
-
-export const TIMER_STATUS = {
-  IDLE: "idle", // 시작 전
-  RUNNING: "running", // 진행 중
-  PAUSED: "paused", // 일시 정지
-  COMPLETED: "completed", // 종료
-  FAILED: "failed",
-};
+import { TIMER_STATUS } from "./timerConstants";
 
 function useTimer(studyId, durationSec) {
   const [timerStatus, setTimerStatus] = useState(TIMER_STATUS.IDLE);

--- a/src/hooks/timer/useTimer.js
+++ b/src/hooks/timer/useTimer.js
@@ -1,9 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import {
-  getFocusSession,
-  createFocusSession,
-  updateFocusSession,
-} from "../../api/focus";
+import useFocusSession from "./useFocusSession";
 import useTimerInterval from "./useTimerInterval";
 import useTimerToast from "./useTimerToast";
 import { TIMER_STATUS } from "./timerConstants";
@@ -17,10 +13,6 @@ function useTimer(studyId, durationSec) {
   // 페이지 재진입 시 타이머가 paused 상태인지 여부 (재개 팝업 표시용)
   const [shouldShowResumePopup, setShouldShowResumePopup] = useState(false);
 
-  // 페이지 재진입 시 과거에 진행 중이던 집중 세션 목록
-  const [sessions, setSessions] = useState([]);
-  // 페이지 재진입 시 진행 중이던 집중 세션 목록 모달 상태
-  const [shouldShowSessionList, setShouldShowSessionList] = useState(false);
   // 선택한 세션 정보
   const [selectedSession, setSelectedSession] = useState(null);
   // 사용자가 설정한 세션 제목
@@ -31,6 +23,9 @@ function useTimer(studyId, durationSec) {
 
   const { toast, toastComplete, toastPause, toastError } = useTimerToast();
 
+  const { sessions, shouldShowSessionList, createSession, updateSession } =
+    useFocusSession(studyId);
+
   // 타이머 완료 처리: failed=true일 경우 포인트 미지급
   const handleComplete = useCallback(
     async ({ action = TIMER_STATUS.COMPLETED } = {}) => {
@@ -38,16 +33,9 @@ function useTimer(studyId, durationSec) {
       isCompletingRef.current = true;
 
       try {
-        const res = await updateFocusSession(studyId, sessionIdRef.current, {
-          action,
-        });
-
-        const { data } = res.data;
-
+        const data = await updateSession(sessionIdRef.current, action);
         const pointResult = data.earnedPoint ?? 0;
-        if (action === TIMER_STATUS.COMPLETED) {
-          setEarnedPoint(pointResult);
-        }
+        if (action === TIMER_STATUS.COMPLETED) setEarnedPoint(pointResult);
         toastComplete(action, pointResult);
         setTimerStatus(data.status);
       } catch (e) {
@@ -55,32 +43,13 @@ function useTimer(studyId, durationSec) {
         toastError(e.userMessage);
       }
     },
-    [toastComplete, toastError, studyId],
+    [toastComplete, toastError, updateSession],
   );
 
   const { timeLeft, setTimeLeft, setEndTime, resetEndTime } = useTimerInterval({
     timerStatus,
     onComplete: handleComplete,
   });
-
-  // 페이지 진입 시 세션 조회
-  useEffect(() => {
-    const fetchSession = async () => {
-      try {
-        const res = await getFocusSession(studyId);
-        const { data } = res.data;
-
-        if (!data || data.length === 0) return;
-
-        setSessions(data);
-        setShouldShowSessionList(true);
-      } catch (e) {
-        toastError(e.userMessage);
-      }
-    };
-
-    fetchSession();
-  }, [studyId, handleComplete, toastError]);
 
   // 세션 선택 시 호출 (SessionListModal에서 클릭 시)
   const selectSession = async (session) => {
@@ -100,9 +69,7 @@ function useTimer(studyId, durationSec) {
       }
 
       // 서버에 paused로 요청
-      await updateFocusSession(studyId, session.id, {
-        action: TIMER_STATUS.PAUSED,
-      });
+      await updateSession(session.id, TIMER_STATUS.PAUSED);
 
       resetEndTime();
       setTimeLeft(remaining);
@@ -122,21 +89,14 @@ function useTimer(studyId, durationSec) {
 
   const start = async (title) => {
     try {
-      const res = await createFocusSession(studyId, {
-        durationSec,
-        title,
-      });
-
-      const { data } = res.data;
-
+      const data = await createSession({ durationSec, title });
       sessionIdRef.current = data.id;
       setEndTime(new Date(data.endTime));
       setTimeLeft(durationSec);
       setTimerStatus(data.status);
-      setCurrentTitle(title); // 시작 시 제목 저장
+      setCurrentTitle(title);
     } catch (e) {
       toastError(e.userMessage);
-
       throw e;
     }
   };
@@ -144,12 +104,10 @@ function useTimer(studyId, durationSec) {
   // 일시 정지 (interval만 멈추고 endTimeRef 유지)
   const pause = async () => {
     try {
-      const res = await updateFocusSession(studyId, sessionIdRef.current, {
-        action: TIMER_STATUS.PAUSED,
-      });
-
-      const { data } = res.data;
-
+      const data = await updateSession(
+        sessionIdRef.current,
+        TIMER_STATUS.PAUSED,
+      );
       setTimerStatus(data.status);
       toastPause();
     } catch (e) {
@@ -160,13 +118,10 @@ function useTimer(studyId, durationSec) {
   const resume = async () => {
     try {
       const requestedAt = Date.now(); // 네트워크 요청 직전 시각
-
-      const res = await updateFocusSession(studyId, sessionIdRef.current, {
-        action: TIMER_STATUS.RUNNING,
-      });
-
-      const { data } = res.data;
-
+      const data = await updateSession(
+        sessionIdRef.current,
+        TIMER_STATUS.RUNNING,
+      );
       // 요청~응답 사이 경과 시간만큼 endTime을 앞당겨 네트워크 딜레이 보정
       const elapsed = Date.now() - requestedAt;
       setEndTime(new Date(new Date(data.endTime).getTime() - elapsed));
@@ -176,10 +131,6 @@ function useTimer(studyId, durationSec) {
     }
   };
 
-  const complete = (options) => {
-    handleComplete(options);
-  };
-
   return {
     timerStatus,
     timeLeft,
@@ -187,7 +138,7 @@ function useTimer(studyId, durationSec) {
     start,
     pause,
     resume,
-    complete,
+    complete: (options) => handleComplete(options),
     toast,
     sessionDuration,
     shouldShowResumePopup,

--- a/src/hooks/timer/useTimer.js
+++ b/src/hooks/timer/useTimer.js
@@ -7,6 +7,7 @@ import {
 import useToast from "../useToast";
 import useTimerInterval from "./useTimerInterval";
 import { TIMER_STATUS } from "./timerConstants";
+import { calcRemaining } from "./timerUtils";
 
 function useTimer(studyId, durationSec) {
   const [timerStatus, setTimerStatus] = useState(TIMER_STATUS.IDLE);
@@ -93,9 +94,7 @@ function useTimer(studyId, durationSec) {
     setCurrentTitle(session.title); // 세션 선택 시 제목 저장
 
     if (session.status === TIMER_STATUS.RUNNING) {
-      const remaining = Math.ceil(
-        (new Date(session.endTime).getTime() - Date.now()) / 1000,
-      );
+      const remaining = calcRemaining(session.endTime);
 
       // 타이머가 돌아가는 도중 페이지를 나갔는데, 돌아왔을 때 타이머 시간이 다 지나버린 경우
       if (remaining <= 0) {
@@ -114,11 +113,7 @@ function useTimer(studyId, durationSec) {
       setSessionDuration(session.durationSec);
       setShouldShowResumePopup(true);
     } else if (session.status === TIMER_STATUS.PAUSED) {
-      const remaining = Math.ceil(
-        (new Date(session.endTime).getTime() -
-          new Date(session.pausedAt).getTime()) /
-          1000,
-      );
+      const remaining = calcRemaining(session.endTime, session.pausedAt);
 
       resetEndTime();
       setTimeLeft(remaining > 0 ? remaining : 0);

--- a/src/hooks/timer/useTimer.js
+++ b/src/hooks/timer/useTimer.js
@@ -4,7 +4,6 @@ import {
   createFocusSession,
   updateFocusSession,
 } from "../../api/focus";
-import useToast from "../useToast";
 import useTimerInterval from "./useTimerInterval";
 import useTimerToast from "./useTimerToast";
 import { TIMER_STATUS } from "./timerConstants";

--- a/src/hooks/timer/useTimer.js
+++ b/src/hooks/timer/useTimer.js
@@ -6,6 +6,7 @@ import {
 } from "../../api/focus";
 import useToast from "../useToast";
 import useTimerInterval from "./useTimerInterval";
+import useTimerToast from "./useTimerToast";
 import { TIMER_STATUS } from "./timerConstants";
 import { calcRemaining } from "./timerUtils";
 
@@ -29,7 +30,7 @@ function useTimer(studyId, durationSec) {
   const sessionIdRef = useRef(null);
   const isCompletingRef = useRef(false); // 타이머 완료 API 중복 호출 방어 플래그
 
-  const { toast, showToast } = useToast();
+  const { toast, toastComplete, toastPause, toastError } = useTimerToast();
 
   // 타이머 완료 처리: failed=true일 경우 포인트 미지급
   const handleComplete = useCallback(
@@ -44,21 +45,18 @@ function useTimer(studyId, durationSec) {
 
         const { data } = res.data;
 
+        const pointResult = data.earnedPoint ?? 0;
         if (action === TIMER_STATUS.COMPLETED) {
-          const pointResult = data.earnedPoint ?? 0;
           setEarnedPoint(pointResult);
-          showToast("success", "포인트를 획득했습니다!", pointResult);
-        } else if (action === TIMER_STATUS.FAILED) {
-          showToast("warning", "집중이 종료되어 포인트가 지급되지 않습니다.");
         }
-
+        toastComplete(action, pointResult);
         setTimerStatus(data.status);
       } catch (e) {
         isCompletingRef.current = false;
-        showToast("warning", e.userMessage);
+        toastError(e.userMessage);
       }
     },
-    [showToast, studyId],
+    [toastComplete, toastError, studyId],
   );
 
   const { timeLeft, setTimeLeft, setEndTime, resetEndTime } = useTimerInterval({
@@ -78,12 +76,12 @@ function useTimer(studyId, durationSec) {
         setSessions(data);
         setShouldShowSessionList(true);
       } catch (e) {
-        showToast("warning", e.userMessage);
+        toastError(e.userMessage);
       }
     };
 
     fetchSession();
-  }, [studyId, handleComplete, showToast]);
+  }, [studyId, handleComplete, toastError]);
 
   // 세션 선택 시 호출 (SessionListModal에서 클릭 시)
   const selectSession = async (session) => {
@@ -138,7 +136,8 @@ function useTimer(studyId, durationSec) {
       setTimerStatus(data.status);
       setCurrentTitle(title); // 시작 시 제목 저장
     } catch (e) {
-      showToast("warning", e.userMessage);
+      toastError(e.userMessage);
+
       throw e;
     }
   };
@@ -153,9 +152,9 @@ function useTimer(studyId, durationSec) {
       const { data } = res.data;
 
       setTimerStatus(data.status);
-      showToast("warning", "집중이 중단되었습니다.");
+      toastPause();
     } catch (e) {
-      showToast("warning", e.userMessage);
+      toastError(e.userMessage);
     }
   };
 
@@ -174,7 +173,7 @@ function useTimer(studyId, durationSec) {
       setEndTime(new Date(new Date(data.endTime).getTime() - elapsed));
       setTimerStatus(data.status);
     } catch (e) {
-      showToast("warning", e.userMessage);
+      toastError(e.userMessage);
     }
   };
 

--- a/src/hooks/timer/useTimerInterval.js
+++ b/src/hooks/timer/useTimerInterval.js
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import { TIMER_STATUS } from "./useTimer";
+import { TIMER_STATUS } from "./timerConstants";
 
 function useTimerInterval({ timerStatus, onComplete }) {
   const [timeLeft, setTimeLeft] = useState(0);

--- a/src/hooks/timer/useTimerToast.js
+++ b/src/hooks/timer/useTimerToast.js
@@ -1,0 +1,32 @@
+import { useCallback } from "react";
+import useToast from "../useToast";
+import { TIMER_STATUS } from "./timerConstants";
+
+function useTimerToast() {
+  const { toast, showToast } = useToast();
+
+  const toastComplete = useCallback(
+    (action, point) => {
+      if (action === TIMER_STATUS.COMPLETED) {
+        showToast("success", "포인트를 획득했습니다!", point);
+      } else if (action === TIMER_STATUS.FAILED) {
+        showToast("warning", "집중이 종료되어 포인트가 지급되지 않습니다.");
+      }
+    },
+    [showToast],
+  );
+
+  const toastPause = useCallback(
+    () => showToast("warning", "집중이 중단되었습니다."),
+    [showToast],
+  );
+
+  const toastError = useCallback(
+    (msg) => showToast("warning", msg),
+    [showToast],
+  );
+
+  return { toast, toastComplete, toastPause, toastError };
+}
+
+export default useTimerToast;

--- a/src/hooks/useTimer.js
+++ b/src/hooks/useTimer.js
@@ -5,6 +5,7 @@ import {
   updateFocusSession,
 } from "../api/focus";
 import useToast from "./useToast";
+import useTimerInterval from "./useTimerInterval";
 
 export const TIMER_STATUS = {
   IDLE: "idle", // 시작 전
@@ -16,7 +17,6 @@ export const TIMER_STATUS = {
 
 function useTimer(studyId, durationSec) {
   const [timerStatus, setTimerStatus] = useState(TIMER_STATUS.IDLE);
-  const [timeLeft, setTimeLeft] = useState(durationSec);
   const [earnedPoint, setEarnedPoint] = useState(0);
   // 페이지 재진입 시 타이머 설정 시간 표시용
   const [sessionDuration, setSessionDuration] = useState(null);
@@ -29,12 +29,9 @@ function useTimer(studyId, durationSec) {
   const [shouldShowSessionList, setShouldShowSessionList] = useState(false);
   // 선택한 세션 정보
   const [selectedSession, setSelectedSession] = useState(null);
-
   // 사용자가 설정한 세션 제목
   const [currentTitle, setCurrentTitle] = useState(null);
 
-  const endTimeRef = useRef(null); // Date.now와 종료 시각을 기준으로 남은 시간 계산
-  const intervalIdRef = useRef(null); // 현재 실행 중인 Interval의 ID
   const sessionIdRef = useRef(null);
   const isCompletingRef = useRef(false); // 타이머 완료 API 중복 호출 방어 플래그
 
@@ -65,11 +62,15 @@ function useTimer(studyId, durationSec) {
       } catch (e) {
         isCompletingRef.current = false;
         showToast("warning", e.userMessage);
-        console.log(e);
       }
     },
     [showToast, studyId],
   );
+
+  const { timeLeft, setTimeLeft, setEndTime, resetEndTime } = useTimerInterval({
+    timerStatus,
+    onComplete: handleComplete,
+  });
 
   // 페이지 진입 시 세션 조회
   useEffect(() => {
@@ -114,7 +115,7 @@ function useTimer(studyId, durationSec) {
         action: TIMER_STATUS.PAUSED,
       });
 
-      endTimeRef.current = null;
+      resetEndTime();
       setTimeLeft(remaining);
       setTimerStatus(TIMER_STATUS.PAUSED);
       setSessionDuration(session.durationSec);
@@ -126,42 +127,13 @@ function useTimer(studyId, durationSec) {
           1000,
       );
 
-      endTimeRef.current = null;
+      resetEndTime();
       setTimeLeft(remaining > 0 ? remaining : 0);
       setTimerStatus(TIMER_STATUS.PAUSED);
       setSessionDuration(session.durationSec);
       setShouldShowResumePopup(true);
     }
   };
-
-  // 타이머 실행
-  useEffect(() => {
-    if (timerStatus !== TIMER_STATUS.RUNNING) {
-      clearInterval(intervalIdRef.current);
-      return;
-    }
-
-    // running일 때만 타이머 동작
-    intervalIdRef.current = setInterval(() => {
-      if (!endTimeRef.current) return;
-
-      // 현재 시각과 목표 종료 시각의 차이를 초 단위로 계산
-      const remaining = Math.ceil(
-        (endTimeRef.current.getTime() - Date.now()) / 1000,
-      );
-
-      if (remaining <= 0) {
-        clearInterval(intervalIdRef.current);
-        setTimeLeft(0);
-        handleComplete();
-      } else {
-        setTimeLeft(remaining);
-      }
-    }, 1000);
-
-    // cleanup 함수: timerStatus 변경이나 언마운트 시 interval 제거
-    return () => clearInterval(intervalIdRef.current);
-  }, [timerStatus, handleComplete]);
 
   const start = async (title) => {
     try {
@@ -173,7 +145,7 @@ function useTimer(studyId, durationSec) {
       const { data } = res.data;
 
       sessionIdRef.current = data.id;
-      endTimeRef.current = new Date(data.endTime);
+      setEndTime(new Date(data.endTime));
       setTimeLeft(durationSec);
       setTimerStatus(data.status);
       setCurrentTitle(title); // 시작 시 제목 저장
@@ -211,7 +183,7 @@ function useTimer(studyId, durationSec) {
 
       // 요청~응답 사이 경과 시간만큼 endTime을 앞당겨 네트워크 딜레이 보정
       const elapsed = Date.now() - requestedAt;
-      endTimeRef.current = new Date(new Date(data.endTime).getTime() - elapsed);
+      setEndTime(new Date(new Date(data.endTime).getTime() - elapsed));
       setTimerStatus(data.status);
     } catch (e) {
       showToast("warning", e.userMessage);

--- a/src/hooks/useTimerInterval.js
+++ b/src/hooks/useTimerInterval.js
@@ -1,0 +1,49 @@
+import { useState, useEffect, useRef } from "react";
+import { TIMER_STATUS } from "./useTimer";
+
+function useTimerInterval({ timerStatus, onComplete }) {
+  const [timeLeft, setTimeLeft] = useState(0);
+  const endTimeRef = useRef(null); // Date.now와 종료 시각을 기준으로 남은 시간 계산
+  const intervalIdRef = useRef(null); // 현재 실행 중인 Interval의 ID
+
+  // 타이머 실행
+  useEffect(() => {
+    if (timerStatus !== TIMER_STATUS.RUNNING) {
+      clearInterval(intervalIdRef.current);
+      return;
+    }
+
+    // running일 때만 타이머 동작
+    intervalIdRef.current = setInterval(() => {
+      if (!endTimeRef.current) return;
+
+      // 현재 시각과 목표 종료 시각의 차이를 초 단위로 계산
+      const remaining = Math.ceil(
+        (endTimeRef.current.getTime() - Date.now()) / 1000,
+      );
+
+      if (remaining <= 0) {
+        clearInterval(intervalIdRef.current);
+        setTimeLeft(0);
+        onComplete();
+      } else {
+        setTimeLeft(remaining);
+      }
+    }, 1000);
+
+    // cleanup 함수: timerStatus 변경이나 언마운트 시 interval 제거
+    return () => clearInterval(intervalIdRef.current);
+  }, [timerStatus, onComplete]);
+
+  const setEndTime = (date) => {
+    endTimeRef.current = date;
+  };
+
+  const resetEndTime = () => {
+    endTimeRef.current = null;
+  };
+
+  return { timeLeft, setTimeLeft, setEndTime, resetEndTime };
+}
+
+export default useTimerInterval;

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -5,11 +5,12 @@ import BoxHeaderInfo from "../../components/BoxHeader/BoxHeaderInfo";
 import NavButton from "../../components/NavButton/NavButton";
 import Toast from "../../components/Toast/Toast";
 import Modal from "../../components/Modal/Modal";
+import useTimer from "../../hooks/timer/useTimer";
+import { TIMER_STATUS } from "../../hooks/timer/timerConstants";
 import ResumeConfirmPopup from "./components/ResumeConfirmPopup";
 import StopConfirmPopup from "./components/StopConfirmPopup";
 import SessionTitleInput from "./components/SessionTitleInput";
 import SessionListModal from "./components/SessionListModal";
-import useTimer, { TIMER_STATUS } from "../../hooks/useTimer";
 import formatTime from "./formatTime";
 import styles from "./Focus.module.css";
 


### PR DESCRIPTION
## 개요
기존 `useTimer` 훅에 interval 계산, API 호출, toast 메시지 처리까지 세 가지 관심사가 섞여 있었습니다.
각 로직이 독립적으로 변경될 가능성이 높다는 멘토님의 피드백을 반영해, 단일 책임 원칙에 따라 분리했습니다.

## 변경 사항
- `timerConstants.js`: `TIMER_STATUS` 상수 분리
- `timerUtils.js`: remaining 계산 유틸 함수 분리
- `useTimerInterval.js`: interval 계산 로직 분리
- `useTimerToast.js`: 토스트 메시지 처리 로직 분리
- `useFocusSession.js`: focus session API 호출 로직 분리
- `useTimer.js`: 위 훅들을 조합하는 역할만 담당하도록 정리
- 위 파일들을 모두 `hooks/timer/` 폴더로 이동

## 영향 범위
- `useTimer`의 return 값은 변경 없음
- `Focus.jsx`에서 `TIMER_STATUS` import 경로 변경 (useTimer → timerConstants)
- 타이머 관련 훅 Import 경로 변경 (`hooks/` → `hooks/timer/`)

## 관련 이슈
- close #70

---
## 코드리뷰 요청 사항
멘토님 안녕하세요. 지난번에 주신 피드백을 반영하여 `useTimer` 훅의 관심사를 분리해보았습니다. 각 파일이 하나의 책임만 갖도록 나누어 보았는데, 이렇게 분리하는 방향이 적절한지 궁금합니다. 보완할 부분이 있다면 피드백 부탁드립니다. 감사합니다!