### PR TITLE
feat: 타이머 완료 유형에 따른 토스트 UX 개선

### DIFF
--- a/src/components/Toast/Toast.jsx
+++ b/src/components/Toast/Toast.jsx
@@ -1,7 +1,7 @@
 import styles from "./Toast.module.css";
 import { createPortal } from "react-dom";
 
-const Toast = ({ type, text, point = 0 }) => {
+const Toast = ({ type, text }) => {
   /**
    * type: success 또는 warning 2개 타입만
    * text: 띄울 문구
@@ -9,7 +9,7 @@ const Toast = ({ type, text, point = 0 }) => {
    */
   return createPortal(
     <div className={`${styles.toast} ${styles[type]}`}>
-      {type === "warning" ? "🚨" : "🎉"} {(point > 0 ? point : "") + text}
+      {type === "warning" ? "🚨" : "🎉"} {text}
     </div>,
     document.body,
   );

--- a/src/hooks/timer/useTimer.js
+++ b/src/hooks/timer/useTimer.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useRef, useCallback } from "react";
 import useFocusSession from "./useFocusSession";
 import useTimerInterval from "./useTimerInterval";
 import useTimerToast from "./useTimerToast";
@@ -28,7 +28,7 @@ function useTimer(studyId, durationSec) {
 
   // 타이머 완료 처리: failed=true일 경우 포인트 미지급
   const handleComplete = useCallback(
-    async ({ action = TIMER_STATUS.COMPLETED } = {}) => {
+    async ({ action = TIMER_STATUS.COMPLETED, isAuto = false } = {}) => {
       if (isCompletingRef.current) return;
       isCompletingRef.current = true;
 
@@ -36,7 +36,7 @@ function useTimer(studyId, durationSec) {
         const data = await updateSession(sessionIdRef.current, action);
         const pointResult = data.earnedPoint ?? 0;
         if (action === TIMER_STATUS.COMPLETED) setEarnedPoint(pointResult);
-        toastComplete(action, pointResult);
+        toastComplete(action, pointResult, isAuto);
         setTimerStatus(data.status);
       } catch (e) {
         isCompletingRef.current = false;
@@ -64,7 +64,7 @@ function useTimer(studyId, durationSec) {
 
       // 타이머가 돌아가는 도중 페이지를 나갔는데, 돌아왔을 때 타이머 시간이 다 지나버린 경우
       if (remaining <= 0) {
-        handleComplete();
+        handleComplete({ action: TIMER_STATUS.COMPLETED, isAuto: true });
         return;
       }
 

--- a/src/hooks/timer/useTimerToast.js
+++ b/src/hooks/timer/useTimerToast.js
@@ -6,9 +6,14 @@ function useTimerToast() {
   const { toast, showToast } = useToast();
 
   const toastComplete = useCallback(
-    (action, point) => {
+    (action, point, isAuto = false) => {
       if (action === TIMER_STATUS.COMPLETED) {
-        showToast("success", "포인트를 획득했습니다!", point);
+        showToast(
+          "success",
+          isAuto
+            ? `집중 시간이 완료되었습니다! ${point}포인트가 지급되었습니다.`
+            : `${point}포인트를 획득했습니다!`,
+        );
       } else if (action === TIMER_STATUS.FAILED) {
         showToast("warning", "집중이 종료되어 포인트가 지급되지 않습니다.");
       }


### PR DESCRIPTION
## 개요
페이지 재진입 후 선택한 세션이 자동 완료되는 경우에도 일반 타이머 완료와 동일한 토스트가 노출되어 UX가 다소 부자연스럽습니다.
그래서 타이머가 실시간으로 완료된 경우와 페이지 재진입 후 이미 만료된 세션을 선택하여 자동 완료되는 경우를 구분해 토스트 메시지를 분기 처리했습니다.

## 변경 사항
- `isAuto` 여부에 따라 Toast 메시지 분기 처리
   - 실시간 완료: 기존 메시지 유지 (`"n포인트를 획득했습니다!"`)
   - 재진입 후 자동 완료: `"집중 시간이 완료되었습니다! n포인트가 지급되었습니다."`
- Toast 공통 컴포넌트에서 `point` 처리 로직 제거
   - `point` 값을 텍스트 앞에 결합하던 방식 제거

## 영향 범위
- Toast 공통 컴포넌트 (`point` props 제거 및 렌더링 로직 변경)

  
## 관련 이슈

- close #78