### PR TITLE
feat : 스터디 수정 시 비밀번호 입력을 옵션으로 만듦

### DIFF
--- a/src/pages/StudyFormPage/components/Form/Form.jsx
+++ b/src/pages/StudyFormPage/components/Form/Form.jsx
@@ -30,6 +30,9 @@ const Form = ({ type, study }) => {
   //배경 이미지 (추후에 따로 분리해두면 좋을듯)
   const [selectedBackground, setSelectedBackground] = useState("GREEN"); //기본값주기?
 
+  //비밀번호 수정 여부 - false: 비밀번호 수정 버튼, true: 비밀번호 입력 창
+  const [editPassword, setEditPassword] = useState(false);
+
   //비밀번호 확인 입력 시, 비밀번호와 일치하는지 검사하고, 일치하지 않다면 문구 띄우기
   useEffect(() => {
     if (password.trim() !== "" && checkPassword.trim() !== "") {
@@ -50,10 +53,10 @@ const Form = ({ type, study }) => {
     //설명 제외 모든 곳에 입력이 되었는지 검사 -> 입력 안된 부분 있으면 토스트 메세지로 띄우기
     if (
       nickname.trim() === "" ||
-      title.trim() === "" ||
-      description.trim() === "" ||
-      password.trim() === "" ||
-      checkPassword.trim() === ""
+      title.trim() === "" //||
+      //description.trim() === "" ||
+      // password.trim() === "" ||
+      // checkPassword.trim() === ""
     ) {
       showToast("warning", "입력이 필요합니다!");
       return;
@@ -66,7 +69,6 @@ const Form = ({ type, study }) => {
 
     //생성/수정 api 보내기
     let result;
-    // study.id = 8; //테스트용
     switch (type) {
       case "create":
         console.log("스터디 생성 요청 시작");
@@ -74,8 +76,8 @@ const Form = ({ type, study }) => {
           title,
           nickname,
           description,
-          password,
           theme: selectedBackground,
+          ...(password ? { password } : {}), //password가 빈 문자열이 아닐때만 password 값을 보냄.
         });
         console.log("result=>", result);
 
@@ -126,25 +128,49 @@ const Form = ({ type, study }) => {
         selectedBackground={selectedBackground}
         setSelectedBackground={setSelectedBackground}
       />
-      <Input
-        input={password}
-        setInput={setPassword}
-        title="비밀번호"
-        placeholder="비밀번호를 입력해 주세요"
-        warningText="* 비밀번호를 입력해 주세요"
-        isPassword={true}
-      />
-      <Input
-        input={checkPassword}
-        setInput={setCheckPassword}
-        title="비밀번호 확인"
-        placeholder="비밀번호를 한번 더 입력해 주세요"
-        isPassword={true}
-        isPasswordCheck={true}
-        isPwSame={isPwSame}
-        pwCheckWarningText={pwCheckWarningText}
-      />
 
+      {editPassword ? (
+        <div className={styles.passwordInputs}>
+          <Input
+            input={password}
+            setInput={setPassword}
+            title="비밀번호"
+            placeholder="비밀번호를 입력해 주세요"
+            warningText="* 비밀번호를 입력해 주세요"
+            isPassword={true}
+          />
+          <Input
+            input={checkPassword}
+            setInput={setCheckPassword}
+            title="비밀번호 확인"
+            placeholder="비밀번호를 한번 더 입력해 주세요"
+            isPassword={true}
+            isPasswordCheck={true}
+            isPwSame={isPwSame}
+            pwCheckWarningText={pwCheckWarningText}
+          />
+          <button
+            className={styles.editPasswordCancelBtn}
+            onClick={() => {
+              setEditPassword(false);
+              setPassword("");
+              setCheckPassword("");
+            }}
+          >
+            비밀번호 수정 취소
+          </button>
+        </div>
+      ) : (
+        <button
+          className={styles.editPasswordBtn}
+          type="button"
+          onClick={() => {
+            setEditPassword(true);
+          }}
+        >
+          비밀번호 수정
+        </button>
+      )}
       <div className={styles.button}>
         <Button
           label={type === "modify" ? "수정하기" : "만들기"}

--- a/src/pages/StudyFormPage/components/Form/Form.jsx
+++ b/src/pages/StudyFormPage/components/Form/Form.jsx
@@ -51,16 +51,35 @@ const Form = ({ type, study }) => {
   //만들기/수정하기 버튼 클릭 시
   const onHandleSubmit = async () => {
     //설명 제외 모든 곳에 입력이 되었는지 검사 -> 입력 안된 부분 있으면 토스트 메세지로 띄우기
-    if (
-      nickname.trim() === "" ||
-      title.trim() === "" //||
-      //description.trim() === "" ||
-      // password.trim() === "" ||
-      // checkPassword.trim() === ""
-    ) {
-      showToast("warning", "입력이 필요합니다!");
-      return;
+    switch (type) {
+      case "create":
+        if (
+          nickname.trim() === "" ||
+          title.trim() === "" ||
+          //description.trim() === "" ||
+          password.trim() === "" ||
+          checkPassword.trim() === ""
+        ) {
+          showToast("warning", "입력이 필요합니다!");
+          return;
+        }
+        break;
+      case "modify":
+        if (
+          nickname.trim() === "" ||
+          title.trim() === "" //||
+          //description.trim() === "" ||
+          // password.trim() === "" ||
+          // checkPassword.trim() === ""
+        ) {
+          showToast("warning", "입력이 필요합니다!");
+          return;
+        }
+        break;
+      default:
+        break;
     }
+
     //비밀번호와 비밀번호 확인이 일치한지 검사 -> 다르면 토스트 메세지로 띄우기
     if (password !== checkPassword) {
       showToast("warning", "비밀번호가 일치하지 않습니다!");
@@ -76,8 +95,8 @@ const Form = ({ type, study }) => {
           title,
           nickname,
           description,
+          password,
           theme: selectedBackground,
-          ...(password ? { password } : {}), //password가 빈 문자열이 아닐때만 password 값을 보냄.
         });
         console.log("result=>", result);
 
@@ -88,8 +107,8 @@ const Form = ({ type, study }) => {
           title,
           nickname,
           description,
-          password,
           theme: selectedBackground,
+          ...(editPassword ? { password } : {}), //password 수정 상태라면 password 값을 보냄.
         });
         console.log("result=>", result);
         break;

--- a/src/pages/StudyFormPage/components/Form/Form.module.css
+++ b/src/pages/StudyFormPage/components/Form/Form.module.css
@@ -7,25 +7,6 @@
   gap: 24px;
 }
 
-/*-----아이콘-----*/
-.pawContainer {
-  width: 32px;
-  height: 32px;
-
-  border-radius: 50%;
-  background-color: rgba(65, 65, 65, 0.5);
-
-  position: absolute;
-
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-.paw {
-  width: 18px;
-  height: 18px;
-}
-
 /*-----Button------*/
 .button {
   width: 100%;
@@ -35,4 +16,51 @@
 /*-----Toast------*/
 .toast {
   z-index: 1000;
+}
+
+.passwordInputs {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+  width: 100%;
+
+  background-color: var(--white);
+  border: 3px solid var(--green);
+  padding: 24px;
+  border-radius: 20px;
+
+  box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.1);
+}
+.editPasswordCancelBtn {
+  background-color: var(--white);
+  padding: 16px;
+  border-radius: 30px;
+  width: fit-content;
+
+  color: var(--black);
+  font-family: Pretendard;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+
+  border: 1px solid var(--green);
+  box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.1);
+}
+.editPasswordBtn {
+  background-color: var(--white);
+  padding: 16px;
+  border-radius: 30px;
+  width: 100%;
+
+  color: var(--black);
+  font-family: Pretendard;
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+
+  border: 1px solid var(--green);
+  box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.1);
 }


### PR DESCRIPTION
## 개요

스터디 수정 시, 사용자의 일반적인 사용 흐름에 따라, 비밀번호를 필수적으로 수정하지 않아도 되도록 함.
스터디 수정 화면에서 버튼 클릭 시 비밀번호를 수정할 수 있도록 함.
비밀번호 수정 취소 시, 비밀번호가 현재 비밀번호로 유지되도록, 요청에 비밀번호를 보내지 않음.

## 변경 사항

- StudyFormFage > `Form.jsx` : 비밀번호 수정 하기, 수정 취소 버튼 추가 및 이에 따른 UI 작성

## 스크린샷 (UI 변경 시)

비밀번호 수정 X
<img width="727" height="269" alt="image" src="https://github.com/user-attachments/assets/a7c50851-4b7d-4d9d-b52d-9f22506efe43" />

비밀번호 수정 O (비밀번호 수정 버튼 클릭 시)
<img width="724" height="468" alt="image" src="https://github.com/user-attachments/assets/2905f3f5-dc01-4e8d-bab1-14bd3043f527" />



## 관련 이슈

- close #79 
