### PR TITLE
feat: 집중 페이지 스터디 포인트 실시간 반영 

### DIFF
--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -152,6 +152,11 @@ function Focus() {
     setShowStopConfirmPopup(false);
   };
 
+  // 획득 포인트 합계
+  const totalPoints =
+    (study?.focusSessions?.reduce((acc, cur) => acc + cur.earnedPoint, 0) ??
+      0) + earnedPoint;
+
   return (
     <section className={styles.container}>
       {toast && (
@@ -206,7 +211,7 @@ function Focus() {
       <StudyHeader
         nickname={study?.nickname}
         title={study?.title}
-        earnedPoint={earnedPoint}
+        earnedPoint={totalPoints}
         onNavigateHabit={() => navigate(`/studies/${studyId}/habits`)}
         onNavigateHome={() => navigate("/")}
       />


### PR DESCRIPTION
## 개요
집중 페이지에서 스터디 포인트가 표시되지 않던 문제를 수정했습니다.
기존 완료 세션 포인트 합계와 현재 세션에서 획득한 포인트를 합산하여 헤더에 실시간으로 반영합니다. 
또한 타이머 완료 시 API 재호출 없이 즉시 반영되도록 처리했습니다.

## 변경 사항
- `focusSessions` 기반 기존 포인트 합계 + `earnedPoint` 합산 로직 추가
- `StudyHeader`에 합산된 포인트 전달

## 관련 이슈
- close #82
