### PR TITLE
Feat/#76 habit delete issue

### DIFF
--- a/src/pages/HabitPage/Habit.jsx
+++ b/src/pages/HabitPage/Habit.jsx
@@ -80,13 +80,18 @@ function Habit() {
     setIsAdding(false);
   };
 
-  // 삭제: 편집 중인 아이템이 삭제되면 편집 상태도 초기화
+  // 삭제: 편집 중인 아이템이 삭제되면 편집 상태도 초기화, stagedEdits에서도 제거
   const handleDelete = async (habitId) => {
     await removeHabit(habitId);
     if (editingHabitId === habitId) {
       setEditingHabitId(null);
       setEditingValue("");
     }
+    setStagedEdits((prev) => {
+      const next = { ...prev };
+      delete next[habitId];
+      return next;
+    });
   };
 
   // + 버튼 클릭: 입력 중인 게 있으면 저장 후 새 입력 열기


### PR DESCRIPTION
## 개요

습관 삭제 시 `stagedEdits`에 해당 habitId가 남아있어, 이후 수정 완료를 누르면
이미 삭제된 습관에 대해 PATCH API가 호출되어 에러가 발생할 가능성이 있음

## 변경 사항

- `handleDelete`에서 `removeHabit` 호출 후 `stagedEdits`에서 해당 habitId도 함께 제거하도록 수정

- close #76 
