### PR TITLE
refactor: React Query 도입으로 getStudyDetail 캐싱 및 로딩 제거

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "12-sprint-part2-project",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.99.2",
         "axios": "^1.15.0",
         "emoji-picker-react": "^4.18.0",
         "react": "^19.2.4",
@@ -57,7 +58,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -267,6 +267,31 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -274,6 +299,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -828,6 +854,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.99.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.2.tgz",
+      "integrity": "sha512-1HunU0bXVsR1ZJMZbcOPE6VtaBJxsW809RE9xPe4Gz7MlB0GWwQvuTPhMoEmQ/hIzFKJ/DWAuttIe7BOaWx0tA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.99.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.2.tgz",
+      "integrity": "sha512-vM91UEe45QUS9ED6OklsVL15i8qKcRqNwpWzPTVWvRPRSEgDudDgHpvyTjcdlwHcrKNa80T+xXYcchT2noPnZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.99.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -859,7 +911,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -906,7 +957,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1032,7 +1082,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1343,7 +1392,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2460,7 +2508,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2531,7 +2578,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2541,7 +2587,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2804,7 +2849,6 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2929,7 +2973,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.99.2",
     "axios": "^1.15.0",
     "emoji-picker-react": "^4.18.0",
     "react": "^19.2.4",

--- a/src/hooks/useStudyDetail.js
+++ b/src/hooks/useStudyDetail.js
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { getStudyDetail } from "../api/studies";
+
+function useStudyDetail(studyId) {
+  return useQuery({
+    queryKey: ["study", studyId],
+    queryFn: () => getStudyDetail(studyId).then((res) => res.data.data),
+    staleTime: 1000 * 60 * 5,
+  });
+}
+
+export default useStudyDetail;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App.jsx";
 import "./styles/global/reset.css";
 import "./styles/global/common.css";
@@ -8,8 +9,12 @@ import "./styles/global/icon.css";
 import "./styles/colors/colors.css";
 import "./styles/fonts/fonts.css";
 
+const queryClient = new QueryClient();
+
 ReactDOM.createRoot(document.getElementById("root")).render(
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>,
+  <QueryClientProvider client={queryClient}>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </QueryClientProvider>,
 );

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { getStudyDetail } from "../../api/studies";
+import { useQueryClient } from "@tanstack/react-query";
 import Toast from "../../components/Toast/Toast";
+import useStudyDetail from "../../hooks/useStudyDetail";
 import useTimer from "../../hooks/timer/useTimer";
 import { TIMER_STATUS } from "../../hooks/timer/timerConstants";
 import TimerSetting from "./components/timer/TimerSetting";
@@ -17,8 +18,8 @@ import styles from "./Focus.module.css";
 function Focus() {
   const navigate = useNavigate();
   const { studyId } = useParams();
+  const queryClient = useQueryClient();
 
-  const [study, setStudy] = useState(null);
   const [durationSec, setDurationSec] = useState(25 * 60);
   const [isEditing, setIsEditing] = useState(false);
   const [inputMin, setInputMin] = useState("25");
@@ -40,15 +41,15 @@ function Focus() {
   const minInputRef = useRef(null);
 
   // 스터디 정보 조회
-  useEffect(() => {
-    const fetchStudy = async () => {
-      const res = await getStudyDetail(studyId);
-      const { data } = res.data;
-      setStudy(data);
-    };
+  const { data: study, isLoading } = useStudyDetail(studyId);
 
-    fetchStudy();
-  }, [studyId]);
+  useEffect(() => {
+    return () => {
+      queryClient.invalidateQueries({
+        queryKey: ["study", studyId],
+      });
+    };
+  }, [queryClient, studyId]);
 
   const {
     timerStatus,
@@ -162,7 +163,6 @@ function Focus() {
       {toast && (
         <Toast type={toast.type} text={toast.text} point={toast.point} />
       )}
-
       {showSessionListModal && (
         <SessionListModal
           sessions={sessions}
@@ -173,7 +173,6 @@ function Focus() {
           onClose={() => setShowSessionListModal(false)}
         />
       )}
-
       {/* 타이머 생성 시 집중 세션 제목 설정 팝업 */}
       {showTitleModal && (
         <SessionTitleModal
@@ -187,7 +186,6 @@ function Focus() {
           onClose={() => setShowTitleModal(false)}
         />
       )}
-
       {/* 페이지 재진입 시 진행 중이던 타이머가 있었던 경우 표시되는 재개 여부 선택 팝업 */}
       {showResumePopup && (
         <ResumeConfirmPopup
@@ -197,7 +195,6 @@ function Focus() {
           title={selectedSession?.title}
         />
       )}
-
       {/* 재진입 팝업에서 종료 선택 시 표시되는 최종 종료 확인 팝업 */}
       {showStopConfirmPopup && (
         <StopConfirmPopup
@@ -206,7 +203,6 @@ function Focus() {
           onStop={handleStopConfirm}
         />
       )}
-
       {/* 스터디 정보 표시 */}
       <StudyHeader
         nickname={study?.nickname}


### PR DESCRIPTION
## 개요
현재 `getStudyDetail`이 StudyDetail, Habit, Focus 페이지에서 각각 독립적으로 호출되고 있어 페이지 이동 시마다 동일한 API가 반복 호출되고 로딩이 발생하는 문제가 있습니다.
React Query를 도입하여 `studyId` 기준으로 데이터를 캐싱하도록 변경하고, 페이지 간 이동 시 캐시된 데이터를 재사용하여 불필요한 API 호출과 로딩을 제거했습니다.
본 PR에서는 공통 훅을 추가하고, `Focus` 페이지에 우선 적용했습니다.

## 변경 사항
- React Query 도입 및 `QueryClientProvider` 설정
- `useStudyDetail` 커스텀 훅 추가
- Focus 페이지 `getStudyDetail` → `useStudyDetail`로 변경
- Focus 페이지 unmount 시 캐시 무효화 추가
    - 타이머 완료 시점이 `useTimer` 내부에 분산되어 있어, 페이지 이탈 시 일괄 invalidate 처리

## 영향 범위
- ⚠️ React Query 의존성 추가로 npm install 실행 필요
- `main.jsx` 변경
- Focus 페이지 (적용 완료)
- StudyDetail / Habit 페이지 (추후 동일 방식 적용 필요)

## 관련 이슈
- close #89
- 자세한 가이드는 노션 팀 문서 참고 부탁드립니다 (https://www.notion.so/React-Query-34a7c51d91288003b2a6c9bb360ed32a)
