### PR TITLE
feat: 스터디 인증 세션 확인 후 비정상 접근 리다이렉트 처리

### DIFF
--- a/src/hooks/useStudySessionCheck.js
+++ b/src/hooks/useStudySessionCheck.js
@@ -16,12 +16,12 @@ function useStudySessionCheck(studyId) {
 
         setTimeout(() => {
           navigate(`/studies/${studyId}`);
-        }, 500);
+        }, 1500);
       }
     };
 
     validateSession();
-  }, [studyId, navigate, showToast]);
+  }, [studyId]);
 }
 
 export default useStudySessionCheck;

--- a/src/hooks/useStudySessionCheck.js
+++ b/src/hooks/useStudySessionCheck.js
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { checkSession } from "../api/studies";
+import useToast from "./useToast";
+
+function useStudySessionCheck(studyId) {
+  const navigate = useNavigate();
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    const validateSession = async () => {
+      try {
+        await checkSession(studyId);
+      } catch {
+        showToast("warning", "스터디 비밀번호 인증 후 이용해주세요.");
+
+        setTimeout(() => {
+          navigate(`/studies/${studyId}`);
+        }, 500);
+      }
+    };
+
+    validateSession();
+  }, [studyId, navigate, showToast]);
+}
+
+export default useStudySessionCheck;

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { getStudyDetail } from "../../api/studies";
+import { getStudyDetail, checkSession } from "../../api/studies";
 import Toast from "../../components/Toast/Toast";
 import useTimer from "../../hooks/timer/useTimer";
 import { TIMER_STATUS } from "../../hooks/timer/timerConstants";
@@ -38,6 +38,19 @@ function Focus() {
 
   // 직접입력 버튼 클릭 시 분 input 포커스용 ref
   const minInputRef = useRef(null);
+
+  useEffect(() => {
+    const validateSession = async () => {
+      try {
+        await checkSession(studyId);
+      } catch (err) {
+        alert("정상 경로로 다시 접속해주세요.");
+        navigate(`/studies/${studyId}`);
+      }
+    };
+
+    validateSession();
+  }, [studyId, navigate]);
 
   // 스터디 정보 조회
   useEffect(() => {

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -14,6 +14,7 @@ import SessionListModal from "./components/session/SessionListModal";
 import StudyHeader from "./components/header/StudyHeader";
 import formatTime from "./formatTime";
 import styles from "./Focus.module.css";
+import useStudySessionCheck from "../../hooks/useStudySessionCheck";
 
 function Focus() {
   const navigate = useNavigate();
@@ -42,7 +43,7 @@ function Focus() {
 
   // 스터디 정보 조회
   const { data: study, isLoading } = useStudyDetail(studyId);
-
+  useStudySessionCheck(studyId);
   useEffect(() => {
     return () => {
       queryClient.invalidateQueries({

--- a/src/pages/HabitPage/Habit.jsx
+++ b/src/pages/HabitPage/Habit.jsx
@@ -5,7 +5,8 @@ import NavButton from "../../components/NavButton/NavButton";
 import BoxHeaderInfo from "../../components/BoxHeader/BoxHeaderInfo";
 import HabitItem from "./components/HabitItem";
 import Modal from "../../components/Modal/Modal";
-import { getStudyDetail, checkSession } from "../../api/studies";
+import { getStudyDetail } from "../../api/studies";
+import useStudySessionCheck from "../../hooks/useStudySessionCheck";
 import useHabits from "../../hooks/useHabits";
 import "../../styles/global/icon.css";
 
@@ -22,19 +23,7 @@ function Habit() {
   const [stagedEdits, setStagedEdits] = useState({});
   const { habits, isLoading, toggleHabit, addHabit, editHabit, removeHabit } =
     useHabits(studyId);
-
-  useEffect(() => {
-    const validateSession = async () => {
-      try {
-        await checkSession(studyId);
-      } catch (err) {
-        alert("정상 경로로 다시 접속해주세요.");
-        navigate(`/studies/${studyId}`);
-      }
-    };
-
-    validateSession();
-  }, [studyId, navigate]);
+  useStudySessionCheck(studyId);
 
   useEffect(() => {
     const fetchStudy = async () => {

--- a/src/pages/HabitPage/Habit.jsx
+++ b/src/pages/HabitPage/Habit.jsx
@@ -5,7 +5,7 @@ import NavButton from "../../components/NavButton/NavButton";
 import BoxHeaderInfo from "../../components/BoxHeader/BoxHeaderInfo";
 import HabitItem from "./components/HabitItem";
 import Modal from "../../components/Modal/Modal";
-import { getStudyDetail } from "../../api/studies";
+import { getStudyDetail, checkSession } from "../../api/studies";
 import useHabits from "../../hooks/useHabits";
 import "../../styles/global/icon.css";
 
@@ -22,6 +22,19 @@ function Habit() {
   const [stagedEdits, setStagedEdits] = useState({});
   const { habits, isLoading, toggleHabit, addHabit, editHabit, removeHabit } =
     useHabits(studyId);
+
+  useEffect(() => {
+    const validateSession = async () => {
+      try {
+        await checkSession(studyId);
+      } catch (err) {
+        alert("정상 경로로 다시 접속해주세요.");
+        navigate(`/studies/${studyId}`);
+      }
+    };
+
+    validateSession();
+  }, [studyId, navigate]);
 
   useEffect(() => {
     const fetchStudy = async () => {


### PR DESCRIPTION
## 개요

스터디 인증 세션 확인 로직을 커스텀 훅으로 분리하여 비정상 접근을 방지했습니다.
오늘의 습관(Habit), 오늘의 집중(Focus) 페이지 진입 시 공통 훅을 통해 세션을 검증하고, 세션이 없거나 만료된 경우 toast 안내 후 스터디 상세 페이지로 리다이렉트되도록 구현했습니다.

## 변경 사항
- 세션 검증 로직을 useStudySessionCheck 커스텀 훅으로 분리
- Habit / Focus 페이지 진입 시 공통 훅을 통해 세션 검증 처리
- 세션 검증 실패 시 toast 메시지 표시
- toast 표시 후 /studies/:studyId 경로로 리다이렉트 처리

## 관련 이슈

- close #91 
