### PR TITLE
feat: 타이머 1분 미만 입력 시 보정 로직 수정

### DIFF
--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -103,14 +103,22 @@ function Focus() {
     setTimeout(() => minInputRef.current?.focus(), 0);
   };
 
-  // input 값대로 타이머 시간 설정
+  // 타이머 시간 설정: 분/초 입력값 보정
   const handleInputChange = (min, sec) => {
     const m = Math.min(99, Math.max(0, parseInt(min) || 1));
     const s = Math.min(59, Math.max(0, parseInt(sec) || 0));
 
-    setInputMin(String(m));
-    setInputSec(String(s).padStart(2, "0"));
-    setDurationSec(Math.max(1, m * 60 + s));
+    let total = m * 60 + s;
+
+    // 1분 미만이면 1:00으로 고정
+    if (total < 60) total = 60;
+
+    const newMin = Math.floor(total / 60);
+    const newSec = total % 60;
+
+    setInputMin(String(newMin));
+    setInputSec(String(newSec).padStart(2, "0"));
+    setDurationSec(total);
   };
 
   // 타이머 start 버튼 클릭 이벤트 핸들러

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -271,6 +271,9 @@ function Focus() {
           ) : (
             formatTime(isIdle || isCompleted ? durationSec : timeLeft)
           )}
+          <p className={styles.helperText}>
+            {isEditing ? "최소 1분부터 설정할 수 있어요" : ""}
+          </p>
         </div>
 
         {/* 타이머 조작 버튼 (시작/일시정지/재시작) */}

--- a/src/pages/FocusPage/Focus.module.css
+++ b/src/pages/FocusPage/Focus.module.css
@@ -60,6 +60,15 @@
   border-bottom: 2px solid var(--brand);
 }
 
+/* 1분 이상 시간 설정 안내 */
+.helperText {
+  height: 1rem;
+  margin-top: 0.5rem;
+  text-align: center;
+  font: var(--text-14-medium);
+  color: var(--gray-500);
+}
+
 /* 타이머 조작 버튼 */
 .btnContainer {
   display: flex;


### PR DESCRIPTION
## 개요
타이머 시간 직접 입력 시 1분 미만 입력이 분 단위로 보정되던 로직을 수정했습니다. 예) 0분 10초 입력 시 1분 10초로 보정됨
따라서 1분 미만 입력 시 1분 0초로 자동 보정되도록 변경했으며, 최소 1분부터 설정할 수 있다는 안내 문구를 추가했습니다.

## 변경 사항
- 1분 미만 입력 시 자동으로 1분으로 보정되도록 변경 (예: 0분 10초 → 1분 0초)
- 최소 1분 설정 안내 문구 추가

## 스크린샷 (UI 변경 시)
### 타이머 시간 직접 입력
<img width="775" height="581" alt="스크린샷 2026-04-22 오후 2 19 46" src="https://github.com/user-attachments/assets/ef82ffeb-0ce1-4d06-a1dc-dd88336df5ba" />

## 관련 이슈
- close #100