### PR TITLE
fix: 스터디 세션 유효성 검사 실패 시 토스트가 표시되지 않는 문제 수정

### DIFF
--- a/src/hooks/useStudySessionCheck.js
+++ b/src/hooks/useStudySessionCheck.js
@@ -16,7 +16,7 @@ function useStudySessionCheck(studyId) {
 
         setTimeout(() => {
           navigate(`/studies/${studyId}`);
-        }, 1500);
+        }, 1000);
       }
     };
 

--- a/src/hooks/useStudySessionCheck.js
+++ b/src/hooks/useStudySessionCheck.js
@@ -5,7 +5,7 @@ import useToast from "./useToast";
 
 function useStudySessionCheck(studyId) {
   const navigate = useNavigate();
-  const { showToast } = useToast();
+  const { toast, showToast } = useToast();
 
   useEffect(() => {
     const validateSession = async () => {
@@ -22,6 +22,8 @@ function useStudySessionCheck(studyId) {
 
     validateSession();
   }, [studyId]);
+
+  return { toast };
 }
 
 export default useStudySessionCheck;

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -41,9 +41,12 @@ function Focus() {
   // 직접입력 버튼 클릭 시 분 input 포커스용 ref
   const minInputRef = useRef(null);
 
+  // 스터디 세션 체크
+  const { toast: sessionToast } = useStudySessionCheck(studyId);
+
   // 스터디 정보 조회
   const { data: study, isLoading } = useStudyDetail(studyId);
-  useStudySessionCheck(studyId);
+
   useEffect(() => {
     return () => {
       queryClient.invalidateQueries({
@@ -171,6 +174,9 @@ function Focus() {
     <section className={styles.container}>
       {toast && (
         <Toast type={toast.type} text={toast.text} point={toast.point} />
+      )}
+      {sessionToast && (
+        <Toast type={sessionToast.type} text={sessionToast.text} />
       )}
       {showSessionListModal && (
         <SessionListModal

--- a/src/pages/HabitPage/Habit.jsx
+++ b/src/pages/HabitPage/Habit.jsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import styles from "./Habit.module.css";
 import NavButton from "../../components/NavButton/NavButton";
 import BoxHeaderInfo from "../../components/BoxHeader/BoxHeaderInfo";
+import Toast from "../../components/Toast/Toast";
 import HabitItem from "./components/HabitItem";
 import Modal from "../../components/Modal/Modal";
 import { getStudyDetail } from "../../api/studies";
@@ -23,7 +24,8 @@ function Habit() {
   const [stagedEdits, setStagedEdits] = useState({});
   const { habits, isLoading, toggleHabit, addHabit, editHabit, removeHabit } =
     useHabits(studyId);
-  useStudySessionCheck(studyId);
+
+  const { toast: sessionToast } = useStudySessionCheck(studyId);
 
   useEffect(() => {
     const fetchStudy = async () => {
@@ -162,6 +164,9 @@ function Habit() {
 
   return (
     <div className={styles.container}>
+      {sessionToast && (
+        <Toast type={sessionToast.type} text={sessionToast.text} />
+      )}
       {/* 헤더 영역 */}
       <div className={styles.studyInfo}>
         <div className={styles.studyTitleRow}>


### PR DESCRIPTION
## 개요
스터디 세션 유효성 검사 실패 시 토스트가 표시되지 않고 즉시 스터디 상세 페이지로 리다이렉트되는 문제가 있어 이를 수정했습니다.
또한 사용자 경험 개선을 위해 토스트 표시 후 리다이렉트 딜레이 시간을 1500ms → 1000ms로 조정했습니다.

## 변경 사항
- `useStudySessionCheck`에서 `toast`를 반환하도록 수정
- 토스트 상태가 UI에 정상적으로 반영되도록 수정
- 리다이렉트 지연 시간 1500ms → 1000ms로 조정

## 영향 범위

- Habit 페이지
- Focus 페이지
- useStudySessionCheck 훅

## 관련 이슈
- close #104
