### PR TITLE
refactor: 습관 React Query 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -268,6 +267,31 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -275,6 +299,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -886,7 +911,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -933,7 +957,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1059,7 +1082,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1370,7 +1392,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2487,7 +2508,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2558,7 +2578,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2568,7 +2587,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2831,7 +2849,6 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2956,7 +2973,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/hooks/useHabits.js
+++ b/src/hooks/useHabits.js
@@ -1,90 +1,74 @@
-import { useState, useEffect, useCallback } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   getTodayHabits,
   createHabit,
   checkHabit,
-  updateHabit as updateHabitApi,
-  deleteHabit as deleteHabitApi,
+  updateHabit,
+  deleteHabit,
 } from "../api/habits";
 
 function useHabits(studyId) {
-  const [habits, setHabits] = useState([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState(null);
+  const queryClient = useQueryClient();
 
-  const fetchHabits = useCallback(async () => {
-    if (!studyId) return;
-    setIsLoading(true);
-    setError(null);
-    try {
-      const res = await getTodayHabits(studyId);
-      console.log("[useHabits] getTodayHabits 응답:", res.data);
-      setHabits(res.data.data);
-    } catch (err) {
-      setError(err.userMessage || "습관을 불러오지 못했습니다.");
-    } finally {
-      setIsLoading(false);
-    }
-  }, [studyId]);
+  // 오늘의 습관 조회
+  const { data: habits = [], isLoading } = useQuery({
+    queryKey: ["habits", studyId],
+    queryFn: () => getTodayHabits(studyId).then((res) => res.data.data),
+    enabled: !!studyId,
+  });
 
-  useEffect(() => {
-    fetchHabits();
-  }, [fetchHabits]);
-
-  // 습관 추가 — BE 응답: { success, data: { id, habitName, ... } }
-  const addHabit = async (habitName) => {
-    const res = await createHabit(studyId, { habitName });
-    const newHabit = res.data.data;
-    setHabits((prev) => [
-      ...prev,
-      { id: newHabit.id, habitName: newHabit.habitName, isCompleted: false },
-    ]);
+  // 캐시 무효화 헬퍼 — habits 캐시 + study 캐시 동시 무효화
+  const invalidateAll = () => {
+    queryClient.invalidateQueries({ queryKey: ["habits", studyId] });
+    queryClient.invalidateQueries({ queryKey: ["study", studyId] });
   };
 
-  // 습관 체크/해제 — BE TODO: 낙관적 업데이트 후 실패 시 롤백
-  const toggleHabit = async (habitId, completed) => {
-    setHabits((prev) =>
-      prev.map((h) =>
-        h.id === habitId ? { ...h, isCompleted: completed } : h,
-      ),
-    );
-    try {
-      await checkHabit(studyId, habitId, { completed });
-    } catch (err) {
-      // 실패 시 원래대로 롤백
-      setHabits((prev) =>
-        prev.map((h) =>
-          h.id === habitId ? { ...h, isCompleted: !completed } : h,
-        ),
+  // 습관 추가
+  const { mutateAsync: addHabitMutation } = useMutation({
+    mutationFn: (habitName) => createHabit(studyId, { habitName }),
+    onSuccess: invalidateAll,
+  });
+
+  // 습관 체크/해제 — 낙관적 업데이트 후 실패 시 롤백
+  const { mutate: toggleHabitMutation } = useMutation({
+    mutationFn: ({ habitId, completed }) =>
+      checkHabit(studyId, habitId, { completed }),
+    onMutate: async ({ habitId, completed }) => {
+      await queryClient.cancelQueries({ queryKey: ["habits", studyId] });
+      const previous = queryClient.getQueryData(["habits", studyId]);
+      queryClient.setQueryData(["habits", studyId], (old) =>
+        old.map((h) => (h.id === habitId ? { ...h, isCompleted: completed } : h)),
       );
-      throw err;
-    }
-  };
+      return { previous };
+    },
+    onError: (err, _, context) => {
+      queryClient.setQueryData(["habits", studyId], context.previous);
+    },
+    onSettled: invalidateAll,
+  });
 
-  // 습관 수정 — BE TODO
-  const editHabit = async (habitId, habitName) => {
-    await updateHabitApi(studyId, habitId, { habitName });
-    setHabits((prev) =>
-      prev.map((h) => (h.id === habitId ? { ...h, habitName } : h)),
-    );
-  };
+  // 습관 수정
+  const { mutateAsync: editHabitMutation } = useMutation({
+    mutationFn: ({ habitId, habitName }) =>
+      updateHabit(studyId, habitId, { habitName }),
+    onSuccess: invalidateAll,
+  });
 
-  // 습관 삭제 — BE TODO
-  const removeHabit = async (habitId) => {
-    await deleteHabitApi(studyId, habitId);
-    setHabits((prev) => prev.filter((h) => h.id !== habitId));
-  };
+  // 습관 삭제
+  const { mutateAsync: removeHabitMutation } = useMutation({
+    mutationFn: (habitId) => deleteHabit(studyId, habitId),
+    onSuccess: invalidateAll,
+  });
 
-  return {
-    habits,
-    isLoading,
-    error,
-    fetchHabits,
-    addHabit,
-    toggleHabit,
-    editHabit,
-    removeHabit,
-  };
+  // 기존 호출부(Habit.jsx) 인터페이스 유지
+  const addHabit = (habitName) => addHabitMutation(habitName);
+  const toggleHabit = (habitId, completed) =>
+    toggleHabitMutation({ habitId, completed });
+  const editHabit = (habitId, habitName) =>
+    editHabitMutation({ habitId, habitName });
+  const removeHabit = (habitId) => removeHabitMutation(habitId);
+
+  return { habits, isLoading, toggleHabit, addHabit, editHabit, removeHabit };
 }
 
 export default useHabits;

--- a/src/pages/HabitPage/Habit.jsx
+++ b/src/pages/HabitPage/Habit.jsx
@@ -1,11 +1,11 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import styles from "./Habit.module.css";
 import NavButton from "../../components/NavButton/NavButton";
 import BoxHeaderInfo from "../../components/BoxHeader/BoxHeaderInfo";
 import HabitItem from "./components/HabitItem";
 import Modal from "../../components/Modal/Modal";
-import { getStudyDetail } from "../../api/studies";
+import useStudyDetail from "../../hooks/useStudyDetail";
 import useStudySessionCheck from "../../hooks/useStudySessionCheck";
 import useHabits from "../../hooks/useHabits";
 import "../../styles/global/icon.css";
@@ -13,7 +13,7 @@ import "../../styles/global/icon.css";
 function Habit() {
   const { studyId } = useParams();
   const navigate = useNavigate();
-  const [study, setStudy] = useState(null);
+  const { data: study } = useStudyDetail(studyId);
   const [showModal, setShowModal] = useState(false);
   const [isAdding, setIsAdding] = useState(false);
   const [habitInput, setHabitInput] = useState("");
@@ -24,18 +24,6 @@ function Habit() {
   const { habits, isLoading, toggleHabit, addHabit, editHabit, removeHabit } =
     useHabits(studyId);
   useStudySessionCheck(studyId);
-
-  useEffect(() => {
-    const fetchStudy = async () => {
-      try {
-        const res = await getStudyDetail(studyId);
-        setStudy(res.data.data);
-      } catch (err) {
-        console.error("스터디 정보를 불러오는데 실패했습니다.", err);
-      }
-    };
-    fetchStudy();
-  }, [studyId]);
 
   // 인라인 편집 시작 / 취소
   const handleEditStart = (habit) => {


### PR DESCRIPTION
## 개요

React Query 적용

## 변경 사항

- `Habit.jsx` — `getStudyDetail` 직접 호출 제거, `useStudyDetail` 훅으로 교체
- `useHabits.js` — 전체 구조를 React Query 기반으로 전환
  - 습관 조회: `useState + useEffect` → `useQuery` (`queryKey: ["habits", studyId]`)
  - 습관 추가 / 수정 / 삭제: 기존 async 함수 → `useMutation` + `invalidateQueries`
  - 습관 토글: 기존 낙관적 업데이트 로직 → `useMutation`의 `onMutate / onError / onSettled`로 이전
  - 변경 발생 시 `["habits", studyId]`와 `["study", studyId]` 두 캐시 동시 무효화

## 캐시 무효화 전략

습관 변경 시 두 캐시를 모두 무효화합니다.

- `["habits", studyId]` — Habit 페이지 (`getTodayHabits` 응답 캐시)
- `["study", studyId]` — StudyDetail 페이지 (`getStudyDetail` 응답에 habits 포함)

```js
const invalidateAll = () => {
  queryClient.invalidateQueries({ queryKey: ["habits", studyId] });
  queryClient.invalidateQueries({ queryKey: ["study", studyId] });
};
```

- close #103
