### PR TITLE
fix: 스터디  생성 페이지 비밀번호 입력 UI 수정

### DIFF
--- a/src/pages/StudyFormPage/components/Form/Form.jsx
+++ b/src/pages/StudyFormPage/components/Form/Form.jsx
@@ -187,7 +187,7 @@ const Form = ({ type, study }) => {
         setSelectedBackground={setSelectedBackground}
       />
 
-      {editPassword ? (
+      {editPassword || type === "create" ? (
         <div className={styles.passwordInputs}>
           <Input
             input={password}
@@ -209,16 +209,18 @@ const Form = ({ type, study }) => {
             pwCheckWarningText={pwCheckWarningText}
             isSubmitClicked={isSubmitClicked}
           />
-          <button
-            className={styles.editPasswordCancelBtn}
-            onClick={() => {
-              setEditPassword(false);
-              setPassword("");
-              setCheckPassword("");
-            }}
-          >
-            비밀번호 수정 취소
-          </button>
+          {type === "modify" && (
+            <button
+              className={styles.editPasswordCancelBtn}
+              onClick={() => {
+                setEditPassword(false);
+                setPassword("");
+                setCheckPassword("");
+              }}
+            >
+              비밀번호 수정 취소
+            </button>
+          )}
         </div>
       ) : (
         <button


### PR DESCRIPTION
## 개요

스터디 생성 페이지의 비밀번호 입력칸이, 스터디 수정 페이지의 비밀번호 입력칸으로 적용되어 있어서,
생성 페이지에 알맞게 비밀번호 입력칸 UI를 수정하였습니다.

## 변경 사항

- `Form.jsx` : type을 조건으로 활용하여, 생성과 수정 페이지의 비밀번호 UI를 렌더링하도록 했다.

## 스크린샷 (UI 변경 시)

스터디 생성 페이지의 비밀번호 UI
<img width="733" height="503" alt="image" src="https://github.com/user-attachments/assets/831cef08-ca61-4ea4-bf9e-7b35b6118614" />


## 관련 이슈

- close #109 
