### PR TITLE
feat: 최근 조회한 스터디 API 연동

### DIFF
--- a/src/api/studies.js
+++ b/src/api/studies.js
@@ -3,6 +3,10 @@ import api from "./instance";
 // 스터디 목록 조회
 export const getStudies = (params) => api.get("/studies", { params });
 
+// 최근 스터디 조회
+export const getRecentStudies = (params) =>
+  api.get("/studies/recent", { params });
+
 // 스터디 생성
 export const createStudy = (body) => api.post("/studies", body);
 

--- a/src/pages/HomePage/Home.jsx
+++ b/src/pages/HomePage/Home.jsx
@@ -28,6 +28,7 @@ const SORTINGS = [
 const Home = () => {
   const [initLoading, setInitLoading] = useState(true); // 초기 로딩
   const [moreLoading, setMoreLoading] = useState(false); // 더보기 로딩
+  const [recentLoading, setRecentLoading] = useState(true); // 최근 조회한 스터디 로딩
   const [studies, setStudies] = useState([]); // 스터디 둘러보기
   const [recentStudies, setRecentStudies] = useState([]); // 최근 조회한 스터디
   const [page, setPage] = useState(1); // 첫 페이지 1
@@ -58,7 +59,7 @@ const Home = () => {
         setUsableMore(has_more);
         setTotal(total);
       } catch (error) {
-        console.error(`데이터 조회 실패: ${error}`);
+        console.error(`스터디 전체 불러오기 실패: ${error}`);
       } finally {
         setInitLoading(false);
       }
@@ -83,7 +84,7 @@ const Home = () => {
         setStudies((prev) => [...prev, ...data]); // 더보기는 append
         setUsableMore(has_more);
       } catch (error) {
-        console.error(`데이터 조회 실패: ${error}`);
+        console.error(`더보기 실패: ${error}`);
       } finally {
         setMoreLoading(false);
       }
@@ -94,16 +95,24 @@ const Home = () => {
 
   useEffect(() => {
     const fetchRecentStudies = async () => {
-      const storaged = JSON.parse(localStorage.getItem(RECENT_STUDIES) || "[]");
-      const params = {
-        ids: storaged.join(","),
-      };
+      try {
+        const storaged = JSON.parse(
+          localStorage.getItem(RECENT_STUDIES) || "[]",
+        );
+        const params = {
+          ids: storaged.join(","),
+        };
 
-      const res = await getRecentStudies(params);
-      const { data } = res.data;
-      console.log(res);
+        const res = await getRecentStudies(params);
+        const { data } = res.data;
+        console.log(res);
 
-      setRecentStudies(data);
+        setRecentStudies(data);
+      } catch (error) {
+        console.error(`최근 조회한 스터디 불러오기 실패: ${error}`);
+      } finally {
+        setRecentLoading(false);
+      }
     };
 
     fetchRecentStudies();
@@ -130,7 +139,9 @@ const Home = () => {
         <h2 className={styles.headline}>최근 조회한 스터디</h2>
 
         <div className={`${styles.cardList} ${styles.recent}`}>
-          {recentStudies.length ? (
+          {recentLoading ? (
+            <p className={styles.notification}>불러오는 중...</p>
+          ) : recentStudies.length ? (
             recentStudies.map((study) => {
               const createdAt = new Date(study.createdAt);
               const today = new Date();

--- a/src/pages/HomePage/Home.jsx
+++ b/src/pages/HomePage/Home.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { getStudies } from "../../api/studies";
+import { getRecentStudies, getStudies } from "../../api/studies";
 import useToast from "../../hooks/useToast";
 import Card from "../../components/Card/Card";
 import Toast from "../../components/Toast/Toast";
@@ -93,9 +93,20 @@ const Home = () => {
   }, [page]);
 
   useEffect(() => {
-    const storaged = JSON.parse(localStorage.getItem(RECENT_STUDIES) || "[]");
+    const fetchRecentStudies = async () => {
+      const storaged = JSON.parse(localStorage.getItem(RECENT_STUDIES) || "[]");
+      const params = {
+        ids: storaged.join(","),
+      };
 
-    setRecentStudies(storaged);
+      const res = await getRecentStudies(params);
+      const { data } = res.data;
+      console.log(res);
+
+      setRecentStudies(data);
+    };
+
+    fetchRecentStudies();
   }, []);
 
   const currentSort = SORTINGS.find(

--- a/src/pages/StudyDetailPage/StudyDetail.jsx
+++ b/src/pages/StudyDetailPage/StudyDetail.jsx
@@ -21,15 +21,10 @@ const StudyDetail = () => {
   const { data: study, isLoading: loading } = useStudyDetail(studyId);
   const navigate = useNavigate();
 
-  const saveRecentStudy = (data) => {
-    const recentStudyTotalPoints =
-      data.focusSessions?.reduce((acc, cur) => acc + cur.earnedPoint, 0) ?? 0;
-
-    data.points = recentStudyTotalPoints;
-
+  const saveRecentStudy = (id) => {
     const storaged = JSON.parse(localStorage.getItem(RECENT_STUDIES) || "[]");
-    const filtered = storaged.filter((s) => s.id !== data.id); // 이미 로컬스토리지에 해당 스터디가 저장되어 있는 경우 담지 않음
-    filtered.unshift(data);
+    const filtered = storaged.filter((existId) => existId !== id); // 이미 로컬스토리지에 해당 스터디가 저장되어 있는 경우 담지 않음
+    filtered.unshift(id);
     if (filtered.length > 3) {
       // 3개를 넘어가면 제일 처음에 조회한 스터디 제거
       filtered.pop();
@@ -37,6 +32,10 @@ const StudyDetail = () => {
 
     localStorage.setItem(RECENT_STUDIES, JSON.stringify(filtered));
   };
+
+  useEffect(() => {
+    if (study) saveRecentStudy(study.id);
+  }, [study]);
 
   // 획득 포인트 합계
   const totalPoints =


### PR DESCRIPTION
## 개요

최근 조회한 스터디에 담긴 스터디ID를 쿼리 파라미터로 요청을 보내고, 해당 스터디 데이터들의 정보를 받아서 출력

## 변경 사항

- StudyDetail:
  > 상세 페이지 접속시 스터디 정보를 받아오면 그대로 로컬스토리지에 담았던 부분을 스터디ID 만 담기게 변경
- Home:
  > 최근 조회한 스터디 목록을 api 요청 보내고 받아온 데이터로 출력

## 영향 범위

- /api/studies.js:
  > 최근 조회한 스터디 조회 API get 요청 추가

## 관련 이슈

- close #114 
