### PR TITLE
fix: 타이머 재시작 시 시간 오차 수정

### DIFF
--- a/src/hooks/timer/useTimer.js
+++ b/src/hooks/timer/useTimer.js
@@ -117,14 +117,12 @@ function useTimer(studyId, durationSec) {
 
   const resume = async () => {
     try {
-      const requestedAt = Date.now(); // 네트워크 요청 직전 시각
       const data = await updateSession(
         sessionIdRef.current,
         TIMER_STATUS.RUNNING,
       );
-      // 요청~응답 사이 경과 시간만큼 endTime을 앞당겨 네트워크 딜레이 보정
-      const elapsed = Date.now() - requestedAt;
-      setEndTime(new Date(new Date(data.endTime).getTime() - elapsed));
+
+      setEndTime(new Date(data.endTime));
       setTimerStatus(data.status);
     } catch (e) {
       toastError(e.userMessage);

--- a/src/hooks/timer/useTimerInterval.js
+++ b/src/hooks/timer/useTimerInterval.js
@@ -8,31 +8,38 @@ function useTimerInterval({ timerStatus, onComplete }) {
 
   // 타이머 실행
   useEffect(() => {
-    if (timerStatus !== TIMER_STATUS.RUNNING) {
-      clearInterval(intervalIdRef.current);
+    // RUNNING 상태가 아니거나 종료시간이 없으면 Interva 종료
+    if (timerStatus !== TIMER_STATUS.RUNNING || !endTimeRef.current) {
+      if (intervalIdRef.current) clearInterval(intervalIdRef.current);
       return;
     }
 
-    // running일 때만 타이머 동작
-    intervalIdRef.current = setInterval(() => {
+    // 시간 계산 로직을 별도로 분리
+    const updateTick = () => {
       if (!endTimeRef.current) return;
 
-      // 현재 시각과 목표 종료 시각의 차이를 초 단위로 계산
-      const remaining = Math.ceil(
-        (endTimeRef.current.getTime() - Date.now()) / 1000,
-      );
+      const now = Date.now();
+      const end = endTimeRef.current.getTime();
+      const diff = end - now;
+
+      const remaining = Math.max(0, Math.ceil(diff / 1000));
+      setTimeLeft(remaining);
 
       if (remaining <= 0) {
-        clearInterval(intervalIdRef.current);
-        setTimeLeft(0);
+        if (intervalIdRef.current) clearInterval(intervalIdRef.current);
         onComplete();
-      } else {
-        setTimeLeft(remaining);
       }
-    }, 1000);
+    };
 
-    // cleanup 함수: timerStatus 변경이나 언마운트 시 interval 제거
-    return () => clearInterval(intervalIdRef.current);
+    // 즉시 실행
+    updateTick();
+
+    // 200ms 주기로 업데이트
+    intervalIdRef.current = setInterval(updateTick, 200);
+
+    return () => {
+      if (intervalIdRef.current) clearInterval(intervalIdRef.current);
+    };
   }, [timerStatus, onComplete]);
 
   const setEndTime = (date) => {


### PR DESCRIPTION
## 개요
집중 세션을 일시정지(Pause) 후 다시 시작(Resume)할 때, 타이머의 남은 시간이 약 1~2초 정도 실제보다 짧게 표시되거나 어긋나는 문제를 해결했습니다.

## 변경 사항
- `useTimer.js` 보정 로직 제거
   - 서버 응답(`endTime`)은 이미 서버에 요청이 도달한 시점(`Date.now()`) 기준으로 계산되어 오기 때문에, 클라이언트에서 네트워크 지연 시간(`elapsed`)만큼 한 번 더 이중으로 보정할 필요가 없음
   - 서버가 제공하는 응답(`endTime`)을 그대로 사용하고, 클라이언트 내 수동 보정 로직 삭제

- `useTimerInterval.js`애서 타이머 업데이트 정밀도 향상
   - `timerStatus`가 `RUNNING`으로 변경되는 즉시 `updateTick`을 실행해, 1초를 기다리지 않고 화면에 현재 시간이 즉각 반영되도록 개선
   - `setInterval` 주기를 1000ms에서 200ms로 단축하여 브라우저 지연으로 인한 초 단위로 시간이 튀는 현상을 최소화


## 관련 이슈
- close #116
