### PR TITLE
fix: 로컬스토리지에 담긴게 없으면 api 요청 막기

### DIFF
--- a/src/pages/HomePage/Home.jsx
+++ b/src/pages/HomePage/Home.jsx
@@ -99,12 +99,23 @@ const Home = () => {
         const storaged = JSON.parse(
           localStorage.getItem(RECENT_STUDIES) || "[]",
         );
+
+        if (!storaged.length) {
+          setRecentLoading(false);
+          return;
+        }
+
+        // console.log("로컬스토리지에 담긴 id들 => ", storaged);
+
         const params = {
           ids: storaged.join(","),
         };
 
+        // console.log("api 요청시 보낼 파라미터 => ", params);
+
         const res = await getRecentStudies(params);
         const { data } = res.data;
+
         // console.log(res);
 
         setRecentStudies(data);


### PR DESCRIPTION
## 개요

로컬스토리지에 담긴 스터디id 가 없으면 api 요청 막기

## 변경 사항

- useEffect 에서 최근 조회 스터디 데이터를 불러오기 위해 요청을 보낼 때, 로컬스토리지가 빈배열이면 요청을 보내지 않음

## 관련 이슈

- close #124 
