### PR TITLE
fix: Vercel 배포 환경 새로고침/직접 URL 접근 시 404 에러 해결

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## 개요
Vercel 배포 환경에서 메인 페이지 이외의 URL(예: `/studies`)로 직접 접속하거나 새로고침 시 발생하던 404 에러를 해결했습니다.
- 문제 원인: SPA에서의 라우팅은 클라이언트(React Router)가 처리하지만, 새로고침이나 직접 URL 접근 시엔 서버(Vercel)에 해당 경로로 요청이 전달됨. 이 경우 서버는 해당 경로에 대응하는 실제 정적 파일을 찾으려고 시도함.

## 변경 사항
- `vercel.json` 설정 파일 추가
  - 모든 경로(`/*`) 요청을 `index.html`로 rewrite해, 존재하지 않는 경로 요청 시에도 SPA 라우팅이 정상적으로 동작하도록 보장함.

## 관련 이슈
- close #128
