### PR TITLE
fix: 쿠키-세션 방식에서 localStorage + x-session-id 헤더 방식으로 전환

### DIFF
--- a/src/api/instance.js
+++ b/src/api/instance.js
@@ -3,7 +3,6 @@ import { getErrorMessage } from "../constants/errorMessages";
 
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
-  withCredentials: true, // 모든 요청에, 쿠키를 자동으로 포함시킴. (세션 체크를 위함.)
 });
 
 api.interceptors.response.use(

--- a/src/api/studies.js
+++ b/src/api/studies.js
@@ -26,7 +26,11 @@ export const verifyPassword = (studyId, body) =>
 
 // 세션 검증 (비밀번호가 이미 인증된 스터디인지)
 export const checkSession = (studyId) =>
-  api.get(`/studies/${studyId}/check-session`);
+  api.get(`/studies/${studyId}/check-session`, {
+    headers: {
+      "x-session-id": localStorage.getItem("sessionId"),
+    },
+  });
 
 // 응원 이모지 조회
 export const getEmojis = (studyId) => api.get(`/studies/${studyId}/emojis`);

--- a/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.jsx
+++ b/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.jsx
@@ -57,6 +57,9 @@ const PasswordModal = ({
     }
     try {
       const res = await verifyPassword(studyId, { password });
+
+      const sessionId = res.data.data.sessionId;
+      localStorage.setItem("sessionId", sessionId);
       console.log("비밀번호 검증 결과=>", res);
       setShowModal(false); //비밀번호 일치하면 여기서 모달 닫음.
       onPasswordSuccess();


### PR DESCRIPTION
## 개요
Chrome의 서드파티 쿠키 차단으로 인해, 배포 환경(크로스 도메인: Vercel ↔ Render)에서 기존 express-session 기반 인증이 동작하지 않는 문제가 발생했습니다.
따라서 localStorage에 sessionId를 저장하고 헤더로 전송하는 방식으로 변경했습니다.

## 변경사항
- instance.js에서 `withCredentials: true` 제거
- checkSession에서 x-session-id 헤더에 sessionId 포함하도록 변경
- PasswordModal에서 verifyPassword 응답의 sessionId를 localStorage에 저장

## 관련 이슈
https://github.com/12-sprint-part2-project/12-sprint-part2-project-be/issues/94 (백엔드 레포지토리의 이슈)

