### PR TITLE
fix: x-session-id 헤더 전송을 요청 인터셉터로 일원화

### DIFF
--- a/src/api/instance.js
+++ b/src/api/instance.js
@@ -5,6 +5,15 @@ const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
 });
 
+// 요청 인터셉터 추가
+api.interceptors.request.use((config) => {
+  const sessionId = localStorage.getItem("sessionId");
+  if (sessionId) {
+    config.headers["x-session-id"] = sessionId;
+  }
+  return config;
+});
+
 api.interceptors.response.use(
   (res) => res,
   (error) => {


### PR DESCRIPTION
## 개요
#130에서 checkSession에서만 x-session-id 헤더를 수동으로 추가하던 방식을 요청 인터셉터로 변경해 모든 요청에 자동으로 포함되도록 수정했습니다. 

## 변경 사항
- instance.js에 요청 인터셉터 추가 (모든 요청에 x-session-id 자동 포함)

## 영향 범위
- api/instance.js 파일 수정

## 관련 이슈
https://github.com/12-sprint-part2-project/12-sprint-part2-project-be/issues/94 (백엔드 레포지토리의 이슈)