### PR TITLE
fix: useStudyDetail queryKey studyId를 Number로 변환

### DIFF
--- a/src/hooks/useStudyDetail.js
+++ b/src/hooks/useStudyDetail.js
@@ -3,7 +3,7 @@ import { getStudyDetail } from "../api/studies";
 
 function useStudyDetail(studyId) {
   return useQuery({
-    queryKey: ["study", studyId],
+    queryKey: ["study", Number(studyId)],
     queryFn: () => getStudyDetail(studyId).then((res) => res.data.data),
     staleTime: 1000 * 60 * 5,
   });


### PR DESCRIPTION
## 개요
스터디 수정 완료 후 상세 페이지로 이동했을 때, 수정된 내용이 바로 반영되지 않고 기존 데이터가 그대로 표시되는 문제가 있었습니다.
이는 useParams()의 studyId는 문자열이고 API 응답의 id는 숫자 타입이라 queryKey가 일치하지 않아 캐시 무효화가 되지 않았기 때문이었습니다. 
그래서 데이터 원본 타입에 맞게 `useStudyDetail` 훅에서 `Number(studyId)`로 변환해 타입을 통일했습니다.


## 변경 사항
- `useStudyDetail`: queryKey studyId를 Number로 변환

## 영향 범위
- `useHabits.js`, `Focus.jsx`: `invalidateQueries` 시  `studyId`의 타입 변환 필요
```jsx
// 기존
queryClient.invalidateQueries({ queryKey: ["study", studyId] });

// 변경
queryClient.invalidateQueries({ queryKey: ["study", Number(studyId)] });
```

## 관련 이슈

- close #132
