### PR TITLE
feat: 집중 페이지 홈 버튼 → 스터디 상세 버튼으로 변경

### DIFF
--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -224,7 +224,7 @@ function Focus() {
         title={study?.title}
         earnedPoint={totalPoints}
         onNavigateHabit={() => navigate(`/studies/${studyId}/habits`)}
-        onNavigateHome={() => navigate("/")}
+        onNavigateStudyDetail={() => navigate(`/studies/${studyId}`)}
       />
 
       {/* 타이머 */}

--- a/src/pages/FocusPage/components/header/StudyHeader.jsx
+++ b/src/pages/FocusPage/components/header/StudyHeader.jsx
@@ -7,7 +7,7 @@ function StudyHeader({
   title,
   earnedPoint,
   onNavigateHabit,
-  onNavigateHome,
+  onNavigateStudyDetail,
 }) {
   return (
     <div className={styles.header}>
@@ -17,7 +17,7 @@ function StudyHeader({
         </h2>
         <div className={styles.nav}>
           <NavButton label="오늘의 습관" onClick={onNavigateHabit} />
-          <NavButton label="홈" onClick={onNavigateHome} />
+          <NavButton label="스터디 상세" onClick={onNavigateStudyDetail} />
         </div>
       </div>
 


### PR DESCRIPTION
## 개요
집중 페이지와 습관 페이지의 일관성을 맞추고 사용자 편의를 위해 집중 페이지 헤더의 홈 버튼을 스터디 상세 버튼으로 변경했습니다. (홈 이동은 헤더 로고로 가능하므로)

## 변경 사항
- `StudyHeader`의 홈 버튼을 스터디 상세 버튼으로 변경
- 클릭 시 스터디 상세 페이지로 이동하도록 수정

## 관련 이슈
- close #138
