### PR TITLE
fix: 두 번째 타이머가 완료 처리 안 되는 버그 수정

### DIFF
--- a/src/hooks/timer/useTimer.js
+++ b/src/hooks/timer/useTimer.js
@@ -38,6 +38,7 @@ function useTimer(studyId, durationSec) {
         if (action === TIMER_STATUS.COMPLETED) setEarnedPoint(pointResult);
         toastComplete(action, pointResult, isAuto);
         setTimerStatus(data.status);
+        isCompletingRef.current = false;
       } catch (e) {
         isCompletingRef.current = false;
         toastError(e.userMessage);


### PR DESCRIPTION
## 개요
집중 페이지에서 한 번 타이머를 완료한 뒤, 두 번째 타이머를 진행할 때 시간이 다 되어도 완료 처리가 되지 않고 아무 동작도 하지 않는 버그가 발생했습니다.
한 번 타이머를 완료한 뒤 `isCompletingRef`를 리셋하지 않아 이후 타이머를 다시 시작해도 완료 처리가 되지 않는 것이었습니다.
따라서 타이머 완료 후 `isCompletingRef` 리셋을 추가했습니다.

## 변경 사항
- `useTimer.js`: `handleComplete` 성공 시 `isCompletingRef.current = false` 추가

## 관련 이슈
- close #142
