### PR TITLE
feat: 타이머 조작 버튼 UX 개선 - 종료 버튼 추가

### DIFF
--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -147,6 +147,10 @@ function Focus() {
     } catch {}
   };
 
+  const handleStop = () => {
+    setShowStopConfirmPopup(true);
+  };
+
   // 재진입 팝업에서 "계속 진행" 선택 시 일시정지된 타이머를 재시작하고 팝업 닫기
   const handleResumeConfirm = () => {
     resume();
@@ -292,6 +296,7 @@ function Focus() {
             onStart={handleStartClick}
             onPause={pause}
             onResume={resume}
+            onStop={handleStop}
           />
         </div>
       </div>

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -148,6 +148,7 @@ function Focus() {
   };
 
   const handleStop = () => {
+    pause();
     setShowStopConfirmPopup(true);
   };
 

--- a/src/pages/FocusPage/components/timer/TimerControls.jsx
+++ b/src/pages/FocusPage/components/timer/TimerControls.jsx
@@ -8,6 +8,7 @@ function TimerControls({
   onStart,
   onPause,
   onResume,
+  onStop,
 }) {
   if (isIdle || isCompleted) {
     return (
@@ -37,7 +38,8 @@ function TimerControls({
       <button
         type="button"
         className={`${styles.btnBase} ${styles.timerStartButton}`}
-        disabled={isRunning || isPaused}
+        onClick={onResume}
+        disabled={isRunning}
       >
         <span className="ic play"></span>
         Start!
@@ -46,8 +48,7 @@ function TimerControls({
       <button
         type="button"
         className={`${styles.btnBase} ${styles.btnCircle} ${styles.timerRestartButton}`}
-        onClick={onResume}
-        disabled={isRunning}
+        onClick={onStop}
       >
         <span className="ic restart"></span>
       </button>


### PR DESCRIPTION
## 개요
세 번째 버튼(↺)이 종료 버튼으로 오인지하기 쉽다는 피드백과 종료(초기화) 버튼이 있으면 좋겠다는 피드백을 수용해 타이머 버튼 동작을 변경했습니다.

## 변경 사항
- Start 버튼: 타이머 시작 + 일시정지 후 재개 역할 통합
- 세 번째 버튼(↺): 종료 버튼으로 변경 - 클릭 시 종료 확인 팝업이 표시되며, 팝업이 떠있는 동안 타이머를 정지함  
- 종료 팝업에서 종료 버튼 클릭 시 타이머 즉시 종료 및 리셋

## 스크린샷 (UI 변경 시)

### 타이머 시작
<img width="1780" height="959" alt="스크린샷 2026-04-23 오후 5 53 56" src="https://github.com/user-attachments/assets/a0549cb4-658f-4d09-aa5f-8f8c666a534b" />

### 타이머 중단 버튼 클릭: Start 버튼 클릭 시 재시작
<img width="1310" height="962" alt="스크린샷 2026-04-23 오후 5 43 09" src="https://github.com/user-attachments/assets/2de20693-ad1c-47f5-8630-dac72acac84e" />

### 타이머 종료 버튼 클릭: 타이머 종료 팝업 등장
<img width="1300" height="941" alt="스크린샷 2026-04-23 오후 5 44 48" src="https://github.com/user-attachments/assets/4cf5161b-a23d-4bef-9a71-cc7c079408af" />

### a. 타이머 종료 팝업에서 "계속 진행"을 클릭한 경우
<img width="1328" height="964" alt="스크린샷 2026-04-23 오후 5 45 05" src="https://github.com/user-attachments/assets/6a0b1534-debb-4eb7-920e-6772e9de7649" />

### b. 타이머 종료 팝업에서 "종료"를 클릭한 경우
<img width="1324" height="952" alt="스크린샷 2026-04-23 오후 5 45 56" src="https://github.com/user-attachments/assets/eb10ef8c-058c-4abd-a12d-335c10b26805" />


## 관련 이슈

- close #140
