### PR TITLE
fix: Focus.jsx queryKey studyId 타입 Number로 통일

### DIFF
--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -49,9 +49,7 @@ function Focus() {
 
   useEffect(() => {
     return () => {
-      queryClient.invalidateQueries({
-        queryKey: ["study", studyId],
-      });
+      queryClient.invalidateQueries({ queryKey: ["study", Number(studyId)] });
     };
   }, [queryClient, studyId]);
 


### PR DESCRIPTION
## 개요
`useStudyDetail` 훅에서 queryKey에서 `Number(studyId)`를 적용하여 타입을 통일했습니다. (#134)
이에 따라 `Focus.jsx`의 queryKey studyId 타입도 Number로 통일합니다.

## 변경 사항
- `Focus.jsx`: queryKey studyId 타입 Number로 통일