### PR TITLE
fix: isUpdating 로딩 상태 추가로 pause/resume 중복 요청 방지

### DIFF
--- a/src/hooks/timer/useTimer.js
+++ b/src/hooks/timer/useTimer.js
@@ -8,6 +8,8 @@ import { calcRemaining } from "./timerUtils";
 function useTimer(studyId, durationSec) {
   const [timerStatus, setTimerStatus] = useState(TIMER_STATUS.IDLE);
   const [earnedPoint, setEarnedPoint] = useState(0);
+  const [isUpdating, setIsUpdating] = useState(false);
+
   // 페이지 재진입 시 타이머 설정 시간 표시용
   const [sessionDuration, setSessionDuration] = useState(null);
   // 페이지 재진입 시 타이머가 paused 상태인지 여부 (재개 팝업 표시용)
@@ -105,6 +107,8 @@ function useTimer(studyId, durationSec) {
   // 일시 정지 (interval만 멈추고 endTimeRef 유지)
   const pause = async () => {
     try {
+      setIsUpdating(true);
+
       const data = await updateSession(
         sessionIdRef.current,
         TIMER_STATUS.PAUSED,
@@ -113,11 +117,15 @@ function useTimer(studyId, durationSec) {
       toastPause();
     } catch (e) {
       toastError(e.userMessage);
+    } finally {
+      setIsUpdating(false);
     }
   };
 
   const resume = async () => {
     try {
+      setIsUpdating(true);
+
       const data = await updateSession(
         sessionIdRef.current,
         TIMER_STATUS.RUNNING,
@@ -127,6 +135,8 @@ function useTimer(studyId, durationSec) {
       setTimerStatus(data.status);
     } catch (e) {
       toastError(e.userMessage);
+    } finally {
+      setIsUpdating(false);
     }
   };
 
@@ -146,6 +156,7 @@ function useTimer(studyId, durationSec) {
     selectSession,
     selectedSession,
     currentTitle,
+    isUpdating,
   };
 }
 

--- a/src/pages/FocusPage/Focus.jsx
+++ b/src/pages/FocusPage/Focus.jsx
@@ -69,6 +69,7 @@ function Focus() {
     selectSession,
     selectedSession,
     currentTitle,
+    isUpdating,
   } = useTimer(studyId, durationSec);
 
   useEffect(() => {
@@ -292,6 +293,7 @@ function Focus() {
             isCompleted={isCompleted}
             isRunning={isRunning}
             isPaused={isPaused}
+            isUpdating={isUpdating}
             onStart={handleStartClick}
             onPause={pause}
             onResume={resume}

--- a/src/pages/FocusPage/components/timer/TimerControls.jsx
+++ b/src/pages/FocusPage/components/timer/TimerControls.jsx
@@ -5,6 +5,7 @@ function TimerControls({
   isCompleted,
   isPaused,
   isRunning,
+  isUpdating,
   onStart,
   onPause,
   onResume,
@@ -30,7 +31,7 @@ function TimerControls({
         type="button"
         className={`${styles.btnBase} ${styles.btnCircle} ${styles.timerPauseButton}`}
         onClick={onPause}
-        disabled={isPaused}
+        disabled={isPaused || isUpdating}
       >
         <span className="ic pause"></span>
       </button>
@@ -39,7 +40,7 @@ function TimerControls({
         type="button"
         className={`${styles.btnBase} ${styles.timerStartButton}`}
         onClick={onResume}
-        disabled={isRunning}
+        disabled={isRunning || isUpdating}
       >
         <span className="ic play"></span>
         Start!
@@ -49,6 +50,7 @@ function TimerControls({
         type="button"
         className={`${styles.btnBase} ${styles.btnCircle} ${styles.timerRestartButton}`}
         onClick={onStop}
+        disabled={isUpdating}
       >
         <span className="ic restart"></span>
       </button>


### PR DESCRIPTION
## 개요
pause/resume 버튼을 연속해서 클릭할 경우 API 응답 전에 다음 요청이 가면서 타이머 시간이 비정상적으로 표시되는 버그가 있었습니다.
`useTimer.js`에 `isUpdating` 로딩 상태를 추가하고, `isUpdating = true`일 동안 타이머 조작 버튼을 비활성화해, pause/resume 중복 요청을 방지했습니다.

## 변경 사항
- `useTimer.js`: `isUpdating` 상태 추가, pause/resume에 finally로 리셋
- `Focus.jsx`: `isUpdating` prop 전달
- `TimerControls.jsx`: `isUpdating` 동안 버튼 disabled 처리

## 관련 이슈

- close #146
