### PR TITLE
feat: sessionId 유효시간 및 비밀번호 변경 시 인증 무효화

### DIFF
--- a/src/api/instance.js
+++ b/src/api/instance.js
@@ -5,11 +5,16 @@ const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
 });
 
-// 요청 인터셉터 추가
 api.interceptors.request.use((config) => {
   const sessionId = localStorage.getItem("sessionId");
   if (sessionId) {
-    config.headers["x-session-id"] = sessionId;
+    const timestamp = Number(sessionId.split("-")[0]);
+    const ONE_HOUR = 1000 * 60 * 60;
+    if (Date.now() - timestamp > ONE_HOUR) {
+      localStorage.removeItem("sessionId");
+    } else {
+      config.headers["x-session-id"] = sessionId;
+    }
   }
   return config;
 });

--- a/src/pages/StudyFormPage/components/Form/Form.jsx
+++ b/src/pages/StudyFormPage/components/Form/Form.jsx
@@ -64,6 +64,11 @@ const Form = ({ type, study }) => {
       //console.log("수정 성공");
       const id = result.data.data.id;
       queryClient.invalidateQueries({ queryKey: ["study", id] }); // 기존 캐시 무효화
+
+      if (editPassword) {
+        localStorage.removeItem("sessionId"); // 비밀번호 수정했을 때만 localStorage 삭제
+      }
+
       showToast("success", "등록되었습니다!");
       navigate(`/studies/${id}`);
     },


### PR DESCRIPTION
## 개요
localStorage에 저장된 sessionId에 유효 시간을 추가했습니다. axios interceptor에서 유효시간을 검사하도록 수정했습니다.
또한 스터디 비밀번호 변경 시 기존 인증이 유지되는 문제를 해결하기 위해 비밀번호 수정 성공 시 sessionId를 무효화하도록 처리했습니다.

## 변경 사항
- axios interceptor에서 sessionId 만료 여부 체크 로직 추가 및 만료된 sessionId localStorage 자동 삭제 처리
- 비밀번호 수정 시 기존 sessionId 삭제 로직 추가

## 영향 범위
- axios interceptor 공통 로직 변경
- 비밀번호 수정 성공 처리 로직 변경
- 인증 방식(localStorage sessionId)에 영향

## 관련 이슈
- close #149
