### PR TITLE
feat: NotFoundPage 추가 및 UI 개선

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,7 @@ import StudyDetailPage from "./pages/StudyDetailPage/StudyDetail";
 import StudyFormPage from "./pages/StudyFormPage/StudyForm";
 import HabitPage from "./pages/HabitPage/Habit";
 import FocusPage from "./pages/FocusPage/Focus";
-import PasswordModal from "./pages/StudyDetailPage/components/PasswordModal/PasswordModal";
+import NotFoundPage from "./pages/NotFoundPage/NotFoundPage";
 
 function App() {
   return (
@@ -16,6 +16,7 @@ function App() {
         <Route path="/studies/:studyId" element={<StudyDetailPage />} />
         <Route path="/studies/:studyId/habits" element={<HabitPage />} />
         <Route path="/studies/:studyId/focus" element={<FocusPage />} />
+        <Route path="*" element={<NotFoundPage />} />
       </Route>
     </Routes>
   );

--- a/src/hooks/useStudyDetail.js
+++ b/src/hooks/useStudyDetail.js
@@ -6,6 +6,7 @@ function useStudyDetail(studyId) {
     queryKey: ["study", Number(studyId)],
     queryFn: () => getStudyDetail(studyId).then((res) => res.data.data),
     staleTime: 1000 * 60 * 5,
+    retry: 0,
   });
 }
 

--- a/src/pages/HabitPage/Habit.jsx
+++ b/src/pages/HabitPage/Habit.jsx
@@ -167,7 +167,7 @@ function Habit() {
               onClick={() => navigate(`/studies/${studyId}/focus`)}
             />
             <NavButton
-              label="홈"
+              label="스터디 상세"
               onClick={() => navigate(`/studies/${studyId}`)}
             />
           </div>

--- a/src/pages/NotFoundPage/NotFoundPage.jsx
+++ b/src/pages/NotFoundPage/NotFoundPage.jsx
@@ -1,0 +1,30 @@
+import { useNavigate } from "react-router-dom";
+import styles from "./NotFoundPage.module.css";
+import Button from "../../components/Button/Button";
+
+function NotFoundPage() {
+  const navigate = useNavigate();
+
+  return (
+    <div className={styles.container}>
+      <svg width="64" height="64" viewBox="0 0 64 64" fill="none">
+        <circle cx="32" cy="32" r="30" stroke="#ccc" strokeWidth="3" />
+        <rect x="29" y="18" width="6" height="22" rx="3" fill="#ccc" />
+        <circle cx="32" cy="48" r="3" fill="#ccc" />
+      </svg>
+      <p className={styles.message}>페이지를 찾을 수 없습니다.</p>
+      <p className={styles.descrption}>
+        삭제되었거나 존재하지 않는 페이지입니다.
+      </p>
+      <div className={styles.btnWrapper}>
+        <Button
+          label="홈으로 돌아가기"
+          onClick={() => navigate("/")}
+          className={styles.btnText}
+        />{" "}
+      </div>
+    </div>
+  );
+}
+
+export default NotFoundPage;

--- a/src/pages/NotFoundPage/NotFoundPage.module.css
+++ b/src/pages/NotFoundPage/NotFoundPage.module.css
@@ -1,0 +1,48 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: min(100%, 75rem);
+  min-height: 60vh;
+  padding: 2.5rem;
+  margin: 0 auto;
+  margin-inline: auto;
+  background-color: var(--white);
+  border-radius: 1.25rem;
+}
+
+.message {
+  margin-top: 2rem;
+  text-align: center;
+  font: var(--text-32-bold);
+  color: var(--black);
+}
+
+.descrption {
+  margin-top: 0.3rem;
+  font: var(--text-16-medium);
+  color: var(--gray-500);
+}
+
+.btnWrapper {
+  margin-top: 1.5rem;
+  width: 10rem;
+  height: 3.625rem;
+}
+
+.btnText {
+  font-size: 1rem;
+}
+
+@media all and (max-width: 744px) {
+  .container {
+    padding: 1.5rem;
+  }
+}
+
+@media all and (max-width: 375px) {
+  .container {
+    padding: 1rem;
+  }
+}

--- a/src/pages/StudyDetailPage/StudyDetail.jsx
+++ b/src/pages/StudyDetailPage/StudyDetail.jsx
@@ -12,13 +12,20 @@ import Toast from "../../components/Toast/Toast";
 import HabitTable from "./components/HabitTable/HabitTable";
 import styles from "./StudyDetail.module.css";
 import Emoji from "./components/Emoji/Emoji";
+import NotFoundPage from "../NotFoundPage/NotFoundPage";
 
 const RECENT_STUDIES = "recent_studies";
 
 const StudyDetail = () => {
   const { studyId } = useParams();
-  const { data: study, isLoading: loading } = useStudyDetail(studyId);
   const navigate = useNavigate();
+
+  const {
+    data: study,
+    isLoading: loading,
+    isError,
+    error,
+  } = useStudyDetail(studyId);
 
   const saveRecentStudy = (id) => {
     const storaged = JSON.parse(localStorage.getItem(RECENT_STUDIES) || "[]");
@@ -164,10 +171,12 @@ const StudyDetail = () => {
     setShowDeletePopup(false);
   };
 
+  if (error?.code === "STUDY_NOT_FOUND") return <NotFoundPage />;
+
   return (
     <section className={styles.box}>
       {loading ? (
-        <p className={styles.notification}>스터디 조회중...</p>
+        <p className={styles.notification}>스터디 조회 중...</p>
       ) : (
         <>
           {toast && <Toast type={toast.type} text={toast.text} />}

--- a/src/pages/StudyDetailPage/components/SharingModal/SharingModal.jsx
+++ b/src/pages/StudyDetailPage/components/SharingModal/SharingModal.jsx
@@ -1,5 +1,5 @@
-import React from "react";
 import Modal from "../../../../components/Modal/Modal";
+import styles from "./SharingModal.module.css";
 
 const SharingModal = ({ setShowModal, title, url, onClickConfirm }) => {
   return (
@@ -10,7 +10,7 @@ const SharingModal = ({ setShowModal, title, url, onClickConfirm }) => {
         hasCancel={false}
         hasExit={true}
         confirmText="복사하기"
-        innerComponent={<p>{url}</p>}
+        innerComponent={<p className={styles.url}>{url}</p>}
         onClickConfirm={onClickConfirm}
       />
     </div>

--- a/src/pages/StudyDetailPage/components/SharingModal/SharingModal.module.css
+++ b/src/pages/StudyDetailPage/components/SharingModal/SharingModal.module.css
@@ -1,0 +1,6 @@
+.url {
+  padding: 1rem;
+  font: var(--text-14-regular);
+  border-radius: 1rem;
+  border: 1px solid var(--gray-300);
+}


### PR DESCRIPTION
## 개요
존재하지 않는 URL이나 없는 스터디에 접근했을 때 빈 화면이나 에러가 노출되는 문제를 개선하고, 버튼 텍스트 불일치 및 공유 모달 디자인을 수정했습니다.

## 변경 사항
- 존재하지 않는 URL 접근 시 `NotFoundPage` 표시 (`App.jsx` `*` 라우트 추가)
- 없는 `studyId`로 접근 시 `STUDY_NOT_FOUND` 에러 감지 후 `NotFoundPage` 렌더링 (`StudyDetail`)
- 습관 페이지 스터디 상세 이동 버튼 텍스트 "홈" → "스터디 상세" 수정
- 스터디 링크 공유 모달 링크 영역 디자인 수정

## 스크린샷 (UI 변경 시)

### 존재하지 않는 URL나 없는 `studyId`로 접근 시  `NotFoundPage`
<img width="1103" height="735" alt="스크린샷 2026-04-26 오후 11 00 03" src="https://github.com/user-attachments/assets/8e6c23a3-ae15-44b8-b7a5-3f0a7f815ca7" />

### 습관 페이지 버튼 텍스트 변경
<img width="1138" height="521" alt="스크린샷 2026-04-26 오후 10 58 58" src="https://github.com/user-attachments/assets/4d8981c0-ebe7-4a74-a297-1d7abc072639" />

### 스터디 링크 공유 모달
<img width="706" height="301" alt="스크린샷 2026-04-26 오후 10 57 58" src="https://github.com/user-attachments/assets/62e2d9ec-fd27-42f6-bf38-417bff60c600" />


## 관련 이슈
- close #155