### PR TITLE
refactor : 스터디폼, 스터디 상세(공유, 비밀번호 모달) 정리

### DIFF
--- a/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.jsx
+++ b/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.jsx
@@ -1,11 +1,14 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import styles from "./PasswordModal.module.css";
 import Modal from "../../../../components/Modal/Modal";
 import { verifyPassword } from "../../../../api/studies";
 import useToast from "../../../../hooks/useToast";
 import Toast from "../../../../components/Toast/Toast";
 
-//TODO: innerComponent 를 컴포넌트로 따로 빼기
+/*
+비밀번호 모달
+- 공통 컴포넌트 모달을 사용
+*/
 const PasswordModal = ({
   setShowModal = () => {}, //이 모달을 보여줄지에 대한 상태. 이걸 넘겨주면, Modal에서 setShowModal(false)로 모달을 끌 수 있다.
   studyId, //스터디 id (비밀번호 검증 API에 이용)

--- a/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.module.css
+++ b/src/pages/StudyDetailPage/components/PasswordModal/PasswordModal.module.css
@@ -3,13 +3,13 @@
 
   display: flex;
   flex-direction: column;
-  gap: 28px;
+  gap: 1.75rem;
 }
 .text {
   color: var(--gray-500, #818181);
   text-align: center;
   font-family: Pretendard;
-  font-size: 18px;
+  font-size: 1.125rem;
   font-style: normal;
   font-weight: 500;
   line-height: normal;
@@ -20,7 +20,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 16px;
+  gap: 1rem;
 }
 .inputContainer {
   width: 100%;
@@ -31,32 +31,32 @@
   align-items: center;
 }
 .inputContainer button {
-  width: 20.473px;
-  height: 18.065px;
+  width: 1.2796rem;
+  height: 1.1291rem;
 
   position: absolute;
-  right: 20px;
+  right: 1.25rem;
 }
 .label {
   color: var(--black, #414141);
   font-family: Pretendard;
-  font-size: 18px;
+  font-size: 1.125rem;
   font-style: normal;
   font-weight: 600;
   line-height: normal;
 }
 .input {
-  padding: 15px 20px;
+  padding: 0.9375rem 1.25rem;
 
   width: 100%;
-  height: 48px;
+  height: 3rem;
 
   border-radius: 15px;
   border: 1px solid var(--gray-300, #ddd);
   background: #fff;
 }
 .pwInput {
-  padding-right: 50px; /*visible icon 자리를 위해*/
+  padding-right: 3.125rem; /*visible icon 자리를 위해*/
 }
 
 /*-----Toast------*/

--- a/src/pages/StudyDetailPage/components/SharingModal/SharingModal.jsx
+++ b/src/pages/StudyDetailPage/components/SharingModal/SharingModal.jsx
@@ -1,6 +1,9 @@
 import Modal from "../../../../components/Modal/Modal";
 import styles from "./SharingModal.module.css";
-
+/*
+공유하기 모달
+- 공통 컴포넌트 모달을 사용
+*/
 const SharingModal = ({ setShowModal, title, url, onClickConfirm }) => {
   return (
     <div>

--- a/src/pages/StudyDetailPage/components/SharingModal/SharingModal.module.css
+++ b/src/pages/StudyDetailPage/components/SharingModal/SharingModal.module.css
@@ -1,6 +1,13 @@
 .url {
   padding: 1rem;
-  font: var(--text-14-regular);
   border-radius: 1rem;
   border: 1px solid var(--gray-300);
+
+  color: var(--gray-500, #818181);
+  text-align: center;
+  font-family: Pretendard;
+  font-size: 1.125rem;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
 }

--- a/src/pages/StudyFormPage/StudyForm.jsx
+++ b/src/pages/StudyFormPage/StudyForm.jsx
@@ -1,27 +1,26 @@
-import React, { useEffect, useState } from "react";
 import styles from "./StudyForm.module.css";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 import Form from "./components/Form/Form";
 import Title from "./components/Title/Title";
+/*
+type
+- create : 스터디 생성 폼
+- modify : 스터디 수정 폼
+  ㄴ StudyDetail페이지에서 스터디 수정 시, study 객체를 location으로 넘겨받는다.
 
-//type
-//- modify : 수정을 위한 ui,
-//  StudyDetail에서 study 객체를 넘겨줌.
-//  기존 스터디 객체를 상태변수의 기본 값으로 설정. create면 빈 객체니까 자동으로 빈 값으로 들어갈 것.
-//- create : 생성을 위한 ui
+*/
+
 function StudyForm({ type = "create", study = {} }) {
-  //일단 지금은 navigate로만 접근하기 때문에, 실질적으로 props는 필요가 없음. 그러나 혹시 모르니 남겨둔다..
-  //만약 다른 곳에서 얘를 컴포넌트로 사용하게 된다면..그러면 필요한..
-
-  //현재 Form의 타입과 주어진 study를 검사해보기 위함.
-  useEffect(() => {
-    console.log("type=>", type);
-    console.log("study=>", study);
-  }, []);
+  //create는 빈 값이고, modify는 navigate로 접근되기에 실질적으로 변수를 Props로 써야 하는 것은 아니다. 그러나 확장성을 위해 남겨두겠다.
+  // //디버깅용 코드. 현재 Form의 타입과 주어진 study를 검사해보기 위함.
+  // useEffect(() => {
+  //   console.log("type=>", type);
+  //   console.log("study=>", study);
+  // }, []);
 
   //navigate로 넘어왔을 시, location으로 인자를 꺼내준다.
   const location = useLocation();
-  type = location.state?.type || "create"; //없을 경우, "create"가 유지되는 것이 아니라, undefined가 들어가게 되는 것 같다. 여기에도 그냥 "create"를 default값으로 넣어주었다. props의 create의 기본값은 필요없어지지만, 이해도를 위해 남겨두겠다.
+  type = location.state?.type || "create"; //없을 경우, 기본값인 "create"가 유지되는 것이 아니라, undefined가 들어가게 되므로, "create"를 default값으로 넣어주었다.
   study = location.state?.study;
 
   return (

--- a/src/pages/StudyFormPage/StudyForm.module.css
+++ b/src/pages/StudyFormPage/StudyForm.module.css
@@ -1,11 +1,11 @@
 .container {
-  padding: 20px;
+  padding: 1.25rem;
 }
 .studyFormContainer {
-  padding: 24px 24px 40px 24px;
+  padding: 1.5rem 1.5rem 2.5rem 1.5rem;
 
   width: 100%;
-  max-width: 696px;
+  max-width: 43.5rem;
 
   border-radius: 20px;
   background: var(--white, #fff);
@@ -13,7 +13,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 24px;
+  gap: 1.5rem;
 }
 
 /*-----Form------*/

--- a/src/pages/StudyFormPage/components/Backgrounds/Backgrounds.jsx
+++ b/src/pages/StudyFormPage/components/Backgrounds/Backgrounds.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styles from "./Backgrounds.module.css";
 
 //이미지는 이렇게 가져와야 정상적으로 작동할 확률이 높다.
@@ -6,7 +5,9 @@ import desk1 from "../../../../assets/images/desk1.jpg";
 import desk2 from "../../../../assets/images/desk2.jpg";
 import tile from "../../../../assets/images/tile.jpg";
 import leaf from "../../../../assets/images/leaf.jpg";
-
+/*
+Form의 여러 배경을 선택하는 부분
+*/
 const Backgrounds = ({ selectedBackground, setSelectedBackground }) => {
   const backgrounds = [
     {

--- a/src/pages/StudyFormPage/components/Backgrounds/Backgrounds.module.css
+++ b/src/pages/StudyFormPage/components/Backgrounds/Backgrounds.module.css
@@ -4,13 +4,13 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 16px;
+  gap: 1rem;
 }
 
 .label {
   color: var(--black, #414141);
   font-family: Pretendard;
-  font-size: 18px;
+  font-size: 1.125rem;
   font-style: normal;
   font-weight: 600;
   line-height: normal;
@@ -21,14 +21,14 @@
   width: 100%;
 
   display: flex;
-  gap: 16px;
+  gap: 1rem;
   flex-wrap: wrap;
   align-items: flex-start;
   align-content: flex-start;
 }
 .background {
-  width: 150px;
-  height: 150px;
+  width: 9.375rem;
+  height: 9.375rem;
 
   border-radius: 16px;
   border: 1px solid rgba(0, 0, 0, 0.1);
@@ -67,8 +67,8 @@
 
 /*-----아이콘-----*/
 .pawContainer {
-  width: 32px;
-  height: 32px;
+  width: 2rem;
+  height: 2rem;
 
   border-radius: 50%;
   background-color: rgba(65, 65, 65, 0.5);
@@ -80,6 +80,6 @@
   align-items: center;
 }
 .paw {
-  width: 18px;
-  height: 18px;
+  width: 1.125rem;
+  height: 1.125rem;
 }

--- a/src/pages/StudyFormPage/components/Form/Form.jsx
+++ b/src/pages/StudyFormPage/components/Form/Form.jsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 import Button from "../../../../components/Button/Button";
 import { createStudy, updateStudy } from "../../../../api/studies";

--- a/src/pages/StudyFormPage/components/Form/Form.module.css
+++ b/src/pages/StudyFormPage/components/Form/Form.module.css
@@ -4,14 +4,14 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 24px;
+  gap: 1.5rem;
 }
 
 /*-----Button------*/
 .button {
   width: 100%;
-  max-width: 648px;
-  height: 58px;
+  max-width: 40.5rem;
+  height: 3.625rem;
 }
 /*-----Toast------*/
 .toast {
@@ -22,7 +22,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 24px;
+  gap: 1.5rem;
   width: 100%;
 
   background-color: var(--white);
@@ -41,7 +41,7 @@
 
   color: var(--black);
   font-family: Pretendard;
-  font-size: 18px;
+  font-size: 1.125rem;
   font-style: normal;
   font-weight: 600;
   line-height: normal;
@@ -51,13 +51,13 @@
 }
 .editPasswordCancelBtn {
   background-color: var(--white);
-  padding: 16px;
+  padding: 1rem;
   border-radius: 30px;
   width: fit-content;
 
   color: var(--black);
   font-family: Pretendard;
-  font-size: 16px;
+  font-size: 1rem;
   font-style: normal;
   font-weight: 600;
   line-height: normal;

--- a/src/pages/StudyFormPage/components/Input/Input.jsx
+++ b/src/pages/StudyFormPage/components/Input/Input.jsx
@@ -1,5 +1,13 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import styles from "./Input.module.css";
+
+/*
+Form에 사용되는 Input
+
+자주 쓰이는 요소이기에, 컴포넌트로 분리함.
+
+비밀번호 관련한 인풋은, 기존의 인풋과는 조금 다르게 작동하는 부분이 있으므로, 이를 위한 Props가 여럿 존재한다.
+*/
 
 const Input = ({
   input,

--- a/src/pages/StudyFormPage/components/Input/Input.module.css
+++ b/src/pages/StudyFormPage/components/Input/Input.module.css
@@ -5,12 +5,12 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 16px;
+  gap: 1rem;
 }
 .label {
   color: var(--black, #414141);
   font-family: Pretendard;
-  font-size: 18px;
+  font-size: 1.125rem;
   font-style: normal;
   font-weight: 600;
   line-height: normal;
@@ -19,7 +19,7 @@
   padding: 15px 20px;
 
   width: 100%;
-  height: 48px;
+  height: 3rem;
 
   border-radius: 15px;
   border: 1px solid var(--gray-300, #ddd);
@@ -30,15 +30,15 @@
   transition: all 0.5s;
 }
 .pwInput {
-  padding-right: 50px; /*visible icon 자리를 위해*/
+  padding-right: 3.125rem; /*visible icon 자리를 위해*/
 }
 .textarea {
   padding: 15px 20px;
-  padding-right: 50px; /*visible icon 자리를 위해*/
+  padding-right: 3.125rem; /*visible icon 자리를 위해*/
   resize: none; /* 크기 조절 막기 */
 
   width: 100%;
-  height: 98px;
+  height: 6.125rem;
 
   border-radius: 15px;
   border: 1px solid var(--gray-300, #ddd);
@@ -54,7 +54,7 @@
 .input::placeholder {
   color: var(--gray-500, #818181);
   font-family: Pretendard;
-  font-size: 16px;
+  font-size: 1rem;
   font-style: normal;
   font-weight: 400;
   line-height: normal;
@@ -68,11 +68,11 @@
   align-items: center;
 }
 .inputContainer button {
-  width: 20.473px;
-  height: 18.065px;
+  width: 1.2796rem;
+  height: 1.1291rem;
 
   position: absolute;
-  right: 20px;
+  right: 1.25rem;
 }
 
 /*-----특수 상황-----*/
@@ -83,7 +83,7 @@
 .warningText {
   color: var(--error, #c41013);
   font-family: Pretendard;
-  font-size: 14px;
+  font-size: 0.875rem;
   font-style: normal;
   font-weight: 400;
   line-height: normal;
@@ -91,7 +91,7 @@
 .correctText {
   color: var(--green-text);
   font-family: Pretendard;
-  font-size: 14px;
+  font-size: 0.875rem;
   font-style: normal;
   font-weight: 400;
   line-height: normal;

--- a/src/pages/StudyFormPage/components/Title/Title.jsx
+++ b/src/pages/StudyFormPage/components/Title/Title.jsx
@@ -1,6 +1,13 @@
 import React from "react";
 import styles from "./Title.module.css";
 
+/*
+    Study Form 페이지의 타이틀 명
+    type
+    ㄴ create : 스터디 만들기
+    ㄴ modify : 스터디 수정
+  */
+
 const Title = ({ type }) => {
   return (
     <h2 className={styles.formTitle}>

--- a/src/pages/StudyFormPage/components/Title/Title.module.css
+++ b/src/pages/StudyFormPage/components/Title/Title.module.css
@@ -1,7 +1,7 @@
 .formTitle {
   color: #414141;
   font-family: Pretendard;
-  font-size: 24px;
+  font-size: 1.5rem;
   font-style: normal;
   font-weight: 800;
   line-height: normal;


### PR DESCRIPTION
## 개요

스터디 폼과 스터디 상세의 코드를 정리하였습니다.

## 변경 사항

- 쓰이지 않는 import문을 제거
- px to rem
- 공유 모달의 url 스타일 수정
- 주석 수정 및 추가

## 스크린샷 (UI 변경 시)

스타일이 수정된 공유 모달
<img width="655" height="276" alt="image" src="https://github.com/user-attachments/assets/c83bff61-6ef5-4f91-b607-26cc3497d786" />


## 관련 이슈

- close #160 
